### PR TITLE
This simplifies starting the first instance as a leader

### DIFF
--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -20,6 +20,9 @@ type Config struct {
 	// SingleNode will start the cluster as a single Node (Raft disabled)
 	SingleNode bool `yaml:"singleNode"`
 
+	// StartAsLeader, this will start this node as the leader before other nodes connect
+	StartAsLeader bool `yaml:"startAsLeader"`
+
 	// Interface is the network interface to bind to (default: First Adapter)
 	Interface string `yaml:"interface,omitempty"`
 


### PR DESCRIPTION
Either passing `-l` or `startAsLeader:true` makes the first node deployment much more simple