### PR TITLE
Fixes generation of manifest

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -106,7 +106,7 @@ var kubeVipSampleManifest = &cobra.Command{
 				Containers: []appv1.Container{
 					{
 						Name:  "kube-vip",
-						Image: "plndr/kube-vip:latest",
+						Image: fmt.Sprintf("plndr/kube-vip:%s", Release.Version),
 						SecurityContext: &appv1.SecurityContext{
 							Capabilities: &appv1.Capabilities{
 								Add: []appv1.Capability{


### PR DESCRIPTION
This generates a manifest with the `current` version of `kube-vip`