### PR TITLE
Adds flags for creating configuration

### DIFF
--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -4,12 +4,40 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
 var endPointIndex int // Holds the previous endpoint (for determining decisions on next endpoint)
+
+//ParseBackendConfig -
+func ParseBackendConfig(ep string) (*BackEnd, error) {
+	endpoint := strings.Split(ep, ":")
+	if len(endpoint) != 2 {
+		return nil, fmt.Errorf("Ensure a backend is in in the format address:port, e.g. 10.0.0.1:8080")
+	}
+	p, err := strconv.Atoi(endpoint[1])
+	if err != nil {
+		return nil, err
+	}
+	return &BackEnd{Address: endpoint[0], Port: p}, nil
+}
+
+//ParsePeerConfig -
+func ParsePeerConfig(ep string) (*RaftPeer, error) {
+	endpoint := strings.Split(ep, ":")
+	if len(endpoint) != 3 {
+		return nil, fmt.Errorf("Ensure a peer is in in the format id:address:port, e.g. server1:10.0.0.1:8080")
+	}
+	p, err := strconv.Atoi(endpoint[2])
+	if err != nil {
+		return nil, err
+	}
+	return &RaftPeer{ID: endpoint[0], Address: endpoint[1], Port: p}, nil
+}
 
 //OpenConfig will attempt to read a file and parse it's contents into a configuration
 func OpenConfig(path string) (*Config, error) {
@@ -37,6 +65,13 @@ func OpenConfig(path string) (*Config, error) {
 
 	}
 	return nil, fmt.Errorf("Error reading [%s]", path)
+}
+
+//PrintConfig - will print out an instance of the kubevip config
+func (c *Config) PrintConfig() {
+	b, _ := yaml.Marshal(c)
+
+	fmt.Printf(string(b))
 }
 
 //SampleConfig will create an example configuration and write it to the specified [path]

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -5,11 +5,11 @@ import "net/url"
 // Config defines all of the settings for the Virtual IP / Load-balancer
 type Config struct {
 
-	// Peers are all of the peers within the RAFT cluster
-	RemotePeers []RaftPeer `yaml:"remotePeers"`
-
 	// LocalPeer is the configuration of this host
 	LocalPeer RaftPeer `yaml:"localPeer"`
+
+	// Peers are all of the peers within the RAFT cluster
+	RemotePeers []RaftPeer `yaml:"remotePeers"`
 
 	// VIP is the Virtual IP address exposed for the cluster
 	VIP string `yaml:"vip"`


### PR DESCRIPTION
This adds a large number of flags to create a customised `kube-vip` configuration.

`-h`

```
      --arp                       Use ARP broadcasts to improve VIP re-allocations
      --interface string          Name of the interface to bind to (default "eth0")
      --lbBackends strings        Comma seperated backends, format: address:port (default [192.168.0.1:8080,192.168.0.2:8080])
      --lbBindToVip               Bind example load balancer to VIP
      --lbName string             The name of a load balancer instance (default "Example Load Balancer")
      --lbPort int                Port that load balander will expose on (default 8080)
      --lbType string             Type of load balancer instance (tcp/http) (default "tcp")
      --localPeer string          Settings for this peer, format: id:address:port (default "server1:192.168.0.1:10000")
      --remotePeers stringArray   Comma seperated remotePeers, format: id:address:port (default [server2:192.168.0.2:10000,server3:192.168.0.3:10000])
      --singleNode                Start this instance as a single node
      --startAsLeader             Start this instance as the cluster leader
      --vip string                The Virtual IP addres (default "192.168.0.1")
```