### PR TITLE
Kube-vip now works as an app LB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.1
+VERSION := 0.1.1
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/dockerfile/dockerfile
+++ b/dockerfile/dockerfile
@@ -2,5 +2,6 @@
 FROM scratch
 #Copy binary
 COPY kube-vip kube-vip
+WORKDIR /tmp
 #Run binary
 CMD ["./kube-vip"]

--- a/pkg/kubevip/config_endpoints.go
+++ b/pkg/kubevip/config_endpoints.go
@@ -8,6 +8,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func init() {
+	// Start the index negative as it will be incrememnted of first approach
+	endPointIndex = -1
+}
+
 // ValidateBackEndURLS will run through the endpoints and ensure that they're a valid URL
 func ValidateBackEndURLS(endpoints *[]BackEnd) error {
 
@@ -39,8 +44,7 @@ func ValidateBackEndURLS(endpoints *[]BackEnd) error {
 
 // ReturnEndpointAddr - returns an endpoint
 func (lb LoadBalancer) ReturnEndpointAddr() string {
-
-	if endPointIndex != len(lb.Backends)-1 {
+	if endPointIndex < len(lb.Backends)-1 {
 		endPointIndex++
 	} else {
 		// reset the index to the beginning

--- a/pkg/loadbalancer/lb_tcp.go
+++ b/pkg/loadbalancer/lb_tcp.go
@@ -45,7 +45,6 @@ func (lb *LBInstance) startTCP(bindAddress string) error {
 				return nil
 			default:
 
-				log.Debugln("Waiting on TCP connections")
 				l.SetDeadline(time.Now().Add(1e9))
 				fd, err := l.Accept()
 				if err != nil {

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/davecgh/go-spew/spew"
+	log "github.com/sirupsen/logrus"
+	"github.com/thebsdbox/kube-vip/pkg/cluster"
+	"github.com/thebsdbox/kube-vip/pkg/kubevip"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	watchtools "k8s.io/client-go/tools/watch"
+
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// OutSideCluster allows the controller to be started using a local kubeConfig for testing
+var OutSideCluster bool
+
+type plndrServices struct {
+	Services []service `json:"services"`
+}
+
+type serviceInstance struct {
+	// Virtual IP / Load Balancer configuration
+	vipConfig kubevip.Config
+	// Kubernetes service mapping
+	service service
+	// cluster instance
+	cluster cluster.Cluster
+}
+
+// TODO - call from a package (duplicated struct in the cloud-provider code)
+type service struct {
+	Vip         string `json:"vip"`
+	Port        int    `json:"port"`
+	UID         string `json:"uid"`
+	ServiceName string `json:"serviceName"`
+}
+
+// Manager degines the manager of the load-balancing services
+type Manager struct {
+	clientSet *kubernetes.Clientset
+	configMap string
+	// Keeps track of all running instances
+	serviceInstances []serviceInstance
+}
+
+// NewManager will create a new managing object
+func NewManager(configMap string) (*Manager, error) {
+	var clientset *kubernetes.Clientset
+	if OutSideCluster == false {
+		// This will attempt to load the configuration when running within a POD
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("error creating kubernetes client config: %s", err.Error())
+		}
+		clientset, err = kubernetes.NewForConfig(cfg)
+
+		if err != nil {
+			return nil, fmt.Errorf("error creating kubernetes client: %s", err.Error())
+		}
+		// use the current context in kubeconfig
+	} else {
+		config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
+		if err != nil {
+			panic(err.Error())
+		}
+		clientset, err = kubernetes.NewForConfig(config)
+
+		if err != nil {
+			return nil, fmt.Errorf("error creating kubernetes client: %s", err.Error())
+		}
+	}
+
+	return &Manager{
+		clientSet: clientset,
+		configMap: configMap,
+	}, nil
+}
+
+// Start will begin the ConfigMap watcher
+func (sm *Manager) Start() error {
+	// TODO - Needs changing to (with cancel)
+	ctx := context.TODO()
+
+	// Build a options structure to defined what we're looking for
+	listOptions := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", sm.configMap),
+	}
+	// Watch function
+	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
+	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return sm.clientSet.CoreV1().ConfigMaps("default").Watch(ctx, listOptions)
+		},
+	})
+
+	if err != nil {
+		return fmt.Errorf("error creating watcher: %s", err.Error())
+	}
+
+	ch := rw.ResultChan()
+	defer rw.Stop()
+	log.Infof("Beginning watching Kubernetes configMap [%s]", sm.configMap)
+
+	var svcs plndrServices
+
+	for event := range ch {
+
+		// We need to inspect the event and get ResourceVersion out of it
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			log.Debugf("ConfigMap [%s] has been Created or modified", sm.configMap)
+			cm, ok := event.Object.(*v1.ConfigMap)
+			if !ok {
+				return fmt.Errorf("Unable to parse ConfigMap from watcher")
+			}
+			data := cm.Data["plndr-services"]
+			json.Unmarshal([]byte(data), &svcs)
+			log.Debugf("Found %d services defined in ConfigMap", len(svcs.Services))
+
+			err = sm.syncServices(&svcs)
+			if err != nil {
+				log.Errorf("%v", err)
+			}
+		case watch.Deleted:
+			log.Debugf("ConfigMap [%s] has been Deleted", sm.configMap)
+
+		case watch.Bookmark:
+			// Un-used
+		case watch.Error:
+			log.Infoln("err")
+
+			// This round trip allows us to handle unstructured status
+			errObject := apierrors.FromObject(event.Object)
+			statusErr, ok := errObject.(*apierrors.StatusError)
+			if !ok {
+				log.Fatalf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+				// Retry unknown errors
+				//return false, 0
+			}
+
+			status := statusErr.ErrStatus
+			log.Errorf("%v", status)
+		default:
+		}
+	}
+
+	return nil
+}

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/thebsdbox/kube-vip/pkg/cluster"
+	"github.com/thebsdbox/kube-vip/pkg/kubevip"
+)
+
+func (sm *Manager) stopService(uid string) error {
+	found := false
+	for x := range sm.serviceInstances {
+		if sm.serviceInstances[x].service.UID == uid {
+			found = true
+			sm.serviceInstances[x].cluster.Stop()
+		}
+	}
+	if found == false {
+		return fmt.Errorf("Unable to find/stop service [%s]", uid)
+	}
+	return nil
+}
+
+func (sm *Manager) deleteService(uid string) error {
+	var updatedInstances []serviceInstance
+	found := false
+	for x := range sm.serviceInstances {
+		// Add the running services to the new array
+		if sm.serviceInstances[x].service.UID != uid {
+			updatedInstances = append(updatedInstances, sm.serviceInstances[x])
+		} else {
+			// Flip the found when we match
+			found = true
+		}
+	}
+	if found == false {
+		return fmt.Errorf("Unable to find/stop service [%s]", uid)
+	}
+
+	// Update the service array
+	sm.serviceInstances = updatedInstances
+
+	log.Debugf("Removed [%s] from manager, [%d] services remain", uid, len(sm.serviceInstances))
+
+	return nil
+}
+
+func (sm *Manager) syncServices(s *plndrServices) error {
+	log.Debugf("Service Sync starting")
+	// Iterate through the synchronising services
+	for x := range s.Services {
+		foundInstance := false
+		for y := range sm.serviceInstances {
+			if s.Services[x].UID == sm.serviceInstances[y].service.UID {
+				// We have found this instance in the manager and we can update it
+				foundInstance = true
+			}
+		}
+		// This instance wasn't found, we need to add it to the manager
+		if foundInstance == false {
+			log.Infof("New Service being added [%s] / [%s]", s.Services[x].ServiceName, s.Services[x].UID)
+			// Generate Load Balancer configu
+			newLB := kubevip.LoadBalancer{
+				Name:      fmt.Sprintf("kube-vip generated for [%s]", s.Services[x].ServiceName),
+				Port:      s.Services[x].Port,
+				Type:      "tcp",
+				BindToVip: true,
+			}
+			// Generate new Virtual IP configuration
+			newVip := kubevip.Config{
+				VIP:        s.Services[x].Vip,
+				Interface:  "ens192",
+				SingleNode: true,
+			}
+			// Add Load Balancer Configuration
+			newVip.LoadBalancers = append(newVip.LoadBalancers, newLB)
+			// Create new Virtual IP service for Manager
+			newService := &serviceInstance{
+				vipConfig: newVip,
+				service:   s.Services[x],
+			}
+
+			// TODO - start VIP
+			c, err := cluster.InitCluster(&newService.vipConfig, false)
+			if err != nil {
+				log.Errorf("Failed to add Service [%s] / [%s]", s.Services[x].ServiceName, s.Services[x].UID)
+				return err
+			}
+			err = c.StartSingleNode(&newService.vipConfig, false)
+			if err != nil {
+				log.Errorf("Failed to add Service [%s] / [%s]", s.Services[x].ServiceName, s.Services[x].UID)
+				return err
+			}
+			newService.cluster = *c
+			// Begin watching this service
+			go sm.newWatcher(newService)
+			// Add new service to manager configuration
+			sm.serviceInstances = append(sm.serviceInstances, *newService)
+		}
+	}
+
+	return nil
+}

--- a/pkg/service/watcher.go
+++ b/pkg/service/watcher.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+	log "github.com/sirupsen/logrus"
+	"github.com/thebsdbox/kube-vip/pkg/kubevip"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+)
+
+// This file handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
+
+func (sm *Manager) newWatcher(s *serviceInstance) error {
+	ctx := context.TODO()
+
+	// Build a options structure to defined what we're looking for
+	listOptions := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", s.service.ServiceName),
+	}
+
+	// Watch function
+	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
+	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return sm.clientSet.CoreV1().Endpoints("default").Watch(ctx, listOptions)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error creating watcher: %s", err.Error())
+	}
+
+	ch := rw.ResultChan()
+	defer rw.Stop()
+	log.Infof("Beginning watching Kubernetes Endpoints for service [%s]", s.service.ServiceName)
+
+	for event := range ch {
+
+		// We need to inspect the event and get ResourceVersion out of it
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			log.Debugf("Endpoints for service [%s] have  been Created or modified", s.service.ServiceName)
+			ep, ok := event.Object.(*v1.Endpoints)
+			if !ok {
+				return fmt.Errorf("Unable to parse Endpoints from watcher")
+			}
+
+			s.vipConfig.LoadBalancers[0].Backends = rebuildEndpoints(*ep)
+
+			log.Debugf("Load-Balancer updated with [%d] backends", len(s.vipConfig.LoadBalancers[0].Backends))
+		case watch.Deleted:
+			log.Debugf("Endpoints for service [%s] have been Deleted", s.service.ServiceName)
+			log.Infof("Service [%s] has been deleted, stopping VIP", s.service.ServiceName)
+			// Stopping the service from running
+			sm.stopService(s.service.UID)
+			// Remove this service from the list of services we manage
+			sm.deleteService(s.service.UID)
+			return nil
+		case watch.Bookmark:
+			// Un-used
+		case watch.Error:
+			log.Infoln("err")
+
+			// This round trip allows us to handle unstructured status
+			errObject := apierrors.FromObject(event.Object)
+			statusErr, ok := errObject.(*apierrors.StatusError)
+			if !ok {
+				log.Fatalf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+				// Retry unknown errors
+				//return false, 0
+			}
+
+			status := statusErr.ErrStatus
+			log.Errorf("%v", status)
+		default:
+		}
+	}
+	return nil
+}
+
+func rebuildEndpoints(eps v1.Endpoints) []kubevip.BackEnd {
+	var addresses []string
+	var ports []int32
+
+	for x := range eps.Subsets {
+		// Loop over addresses
+		for y := range eps.Subsets[x].Addresses {
+			addresses = append(addresses, eps.Subsets[x].Addresses[y].IP)
+		}
+		for y := range eps.Subsets[x].Ports {
+			ports = append(ports, eps.Subsets[x].Ports[y].Port)
+		}
+	}
+	var newBackend []kubevip.BackEnd
+	// Build endpoints
+	log.Debugf("Updating %d endpoints", len(addresses))
+
+	for x := range addresses {
+		for y := range ports {
+			// Print out Backends if debug logging is enabled
+			if log.GetLevel() == log.DebugLevel {
+				fmt.Printf("Address: %s Port %d\n", addresses[x], ports[y])
+			}
+			newBackend = append(newBackend, kubevip.BackEnd{
+				Address: addresses[x],
+				Port:    int(ports[y]),
+			})
+		}
+	}
+	return newBackend
+}


### PR DESCRIPTION
Huge changes:

`kube-vip` can now run in the cluster on worker nodes and be used to load balancer services to the outside world.

This is used through the `kube-vip service` sub command, additionally:

- `--configMap` points to the configMap used by the cloud-provider
- `--arp` enables the use of arp broadcasts