### PR TITLE
InCluster VIP now uses leader election

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.1.
+VERSION := 0.1.2
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.1.1
+VERSION := 0.1.
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/example/deploy/0.1.2.yaml
+++ b/example/deploy/0.1.2.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-vip-cluster
+  name: kube-vip-cluster
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kube-vip-cluster
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kube-vip-cluster
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - kube-vip-cluster
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+      - image: thebsdbox/kube-vip:test
+        imagePullPolicy: Always
+        name: kube-vip
+        command:
+        - /kube-vip
+        - service
+        - --configMap
+        - plndr-configmap
+        - --arp
+        - --interface
+        - ens192
+        - --log
+        - "5"
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+      hostNetwork: true
+status: {}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: lease-access
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "list", "put"]
+  - apiGroups: [""]
+    resources: ["configMap"]
+    verbs: ["get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: lease-access
+subjects:
+  - kind: User
+    name: system:serviceaccount:default:default
+roleRef:
+  kind: Role
+  name: lease-access
+  apiGroup: rbac.authorization.k8s.io

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/vishvananda/netlink v1.1.0
 	gopkg.in/yaml.v2 v2.2.8
-	k8s.io/api v0.17.0
-	k8s.io/apimachinery v0.17.0
-	k8s.io/client-go v0.17.0
+	k8s.io/api v0.17.3
+	k8s.io/apimachinery v0.17.3
+	k8s.io/client-go v0.17.3
 	k8s.io/utils v0.0.0-20200124190032-861946025e34 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09Vjb
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -307,6 +308,8 @@ k8s.io/apimachinery v0.17.3 h1:f+uZV6rm4/tHE7xXgLyToprg6xWairaClGVkm2t8omg=
 k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/client-go v0.17.0 h1:8QOGvUGdqDMFrm9sD6IUFl256BcffynGoe80sxgTEDg=
 k8s.io/client-go v0.17.0/go.mod h1:TYgR6EUHs6k45hb6KWjVD6jFZvJV4gHDikv/It0xz+k=
+k8s.io/client-go v0.17.3 h1:deUna1Ksx05XeESH6XGCyONNFfiQmDdqeqUvicvP6nU=
+k8s.io/client-go v0.17.3/go.mod h1:cLXlTMtWHkuK4tD360KpWz2gG2KtdWEr/OT02i3emRQ=
 k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -120,7 +120,7 @@ func (sm *Manager) Start() error {
 	listOptions := metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", sm.configMap),
 	}
-
+	log.Infof("Beginning cluster membership, namespace [%s], lock name [%s], id [%s]", ns, plunderLock, id)
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".
 	lock := &resourcelock.LeaseLock{
@@ -186,8 +186,8 @@ func (sm *Manager) Start() error {
 				log.Infof("Beginning watching Kubernetes configMap [%s]", sm.configMap)
 
 				var svcs plndrServices
-				// signalChan := make(chan os.Signal, 1)
-				// signal.Notify(signalChan, os.Interrupt)
+				//signalChan := make(chan os.Signal, 1)
+				//signal.Notify(signalChan, os.Interrupt)
 				go func() {
 					for event := range ch {
 
@@ -232,6 +232,8 @@ func (sm *Manager) Start() error {
 						}
 					}
 				}()
+
+				<-leaderChan
 			},
 			OnStoppedLeading: func() {
 				// we can do cleanup here
@@ -251,7 +253,7 @@ func (sm *Manager) Start() error {
 		},
 	})
 
-	// <-signalChan
+	//<-signalChan
 	log.Infof("Shutting down Kube-Vip")
 
 	return nil

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/plunder-app/kube-vip/pkg/cluster"
@@ -18,13 +20,17 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	watchtools "k8s.io/client-go/tools/watch"
 
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
 )
+
+const plunderLock = "plunder-lock"
 
 // OutSideCluster allows the controller to be started using a local kubeConfig for testing
 var OutSideCluster bool
@@ -100,94 +106,153 @@ func NewManager(configMap string) (*Manager, error) {
 // Start will begin the ConfigMap watcher
 func (sm *Manager) Start() error {
 
-	// Build a options structure to defined what we're looking for
-	listOptions := metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", sm.configMap),
-	}
-
 	ns, err := returnNameSpace()
 	if err != nil {
 		return err
 	}
 
-	// Watch function
-	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
-	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return sm.clientSet.CoreV1().ConfigMaps(ns).Watch(listOptions)
+	id, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	// Build a options structure to defined what we're looking for
+	listOptions := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", sm.configMap),
+	}
+
+	// we use the Lease lock type since edits to Leases are less common
+	// and fewer objects in the cluster watch "all Leases".
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      plunderLock,
+			Namespace: ns,
+		},
+		Client: sm.clientSet.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	// use a Go context so we can tell the leaderelection code when we
+	// want to step down
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// listen for interrupts or the Linux SIGTERM signal and cancel
+	// our context, which the leader election code will observe and
+	// step down
+	leaderChan := make(chan os.Signal, 1)
+	signal.Notify(leaderChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-leaderChan
+		log.Info("Received termination, signaling shutdown")
+		// Cancel the context, which will in turn cancel the leadership
+		cancel()
+	}()
+
+	// start the leader election code loop
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock: lock,
+		// IMPORTANT: you MUST ensure that any code you have that
+		// is protected by the lease must terminate **before**
+		// you call cancel. Otherwise, you could have a background
+		// loop still running and another process could
+		// get elected before your background loop finished, violating
+		// the stated goal of the lease.
+		ReleaseOnCancel: true,
+		LeaseDuration:   60 * time.Second,
+		RenewDeadline:   15 * time.Second,
+		RetryPeriod:     5 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				// we're notified when we start
+
+				// Watch function
+				// Use a restartable watcher, as this should help in the event of etcd or timeout issues
+				rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						return sm.clientSet.CoreV1().ConfigMaps(ns).Watch(listOptions)
+					},
+				})
+
+				if err != nil {
+					log.Errorf("error creating watcher: %s", err.Error())
+					ctx.Done()
+				}
+
+				ch := rw.ResultChan()
+				defer rw.Stop()
+				log.Infof("Beginning watching Kubernetes configMap [%s]", sm.configMap)
+
+				var svcs plndrServices
+				// signalChan := make(chan os.Signal, 1)
+				// signal.Notify(signalChan, os.Interrupt)
+				go func() {
+					for event := range ch {
+
+						// We need to inspect the event and get ResourceVersion out of it
+						switch event.Type {
+						case watch.Added, watch.Modified:
+							log.Debugf("ConfigMap [%s] has been Created or modified", sm.configMap)
+							cm, ok := event.Object.(*v1.ConfigMap)
+							if !ok {
+								log.Errorf("Unable to parse ConfigMap from watcher")
+								break
+							}
+							data := cm.Data["plndr-services"]
+							json.Unmarshal([]byte(data), &svcs)
+							log.Debugf("Found %d services defined in ConfigMap", len(svcs.Services))
+
+							err = sm.syncServices(&svcs)
+							if err != nil {
+								log.Errorf("%v", err)
+							}
+						case watch.Deleted:
+							log.Debugf("ConfigMap [%s] has been Deleted", sm.configMap)
+
+						case watch.Bookmark:
+							// Un-used
+						case watch.Error:
+							log.Infoln("err")
+
+							// This round trip allows us to handle unstructured status
+							errObject := apierrors.FromObject(event.Object)
+							statusErr, ok := errObject.(*apierrors.StatusError)
+							if !ok {
+								log.Fatalf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+								// Retry unknown errors
+								//return false, 0
+							}
+
+							status := statusErr.ErrStatus
+							log.Errorf("%v", status)
+
+						default:
+						}
+					}
+				}()
+			},
+			OnStoppedLeading: func() {
+				// we can do cleanup here
+				log.Infof("leader lost: %s", id)
+				for x := range sm.serviceInstances {
+					sm.serviceInstances[x].cluster.Stop()
+				}
+			},
+			OnNewLeader: func(identity string) {
+				// we're notified when new leader elected
+				if identity == id {
+					// I just got the lock
+					return
+				}
+				log.Infof("new leader elected: %s", identity)
+			},
 		},
 	})
 
-	if err != nil {
-		return fmt.Errorf("error creating watcher: %s", err.Error())
-	}
-
-	ch := rw.ResultChan()
-	defer rw.Stop()
-	log.Infof("Beginning watching Kubernetes configMap [%s]", sm.configMap)
-
-	var svcs plndrServices
-	signalChan := make(chan os.Signal, 1)
-
-	// Add Notification for Userland interrupt
-	signal.Notify(signalChan, syscall.SIGINT)
-
-	// Add Notification for SIGTERM (sent from Kubernetes)
-	signal.Notify(signalChan, syscall.SIGTERM)
-
-	// Add Notification for SIGKILL (sent from Kubernetes)
-	signal.Notify(signalChan, syscall.SIGKILL)
-
-	go func() {
-		for event := range ch {
-
-			// We need to inspect the event and get ResourceVersion out of it
-			switch event.Type {
-			case watch.Added, watch.Modified:
-				log.Debugf("ConfigMap [%s] has been Created or modified", sm.configMap)
-				cm, ok := event.Object.(*v1.ConfigMap)
-				if !ok {
-					log.Errorf("Unable to parse ConfigMap from watcher")
-					break
-				}
-				data := cm.Data["plndr-services"]
-				json.Unmarshal([]byte(data), &svcs)
-				log.Debugf("Found %d services defined in ConfigMap", len(svcs.Services))
-
-				err = sm.syncServices(&svcs)
-				if err != nil {
-					log.Errorf("%v", err)
-				}
-			case watch.Deleted:
-				log.Debugf("ConfigMap [%s] has been Deleted", sm.configMap)
-
-			case watch.Bookmark:
-				// Un-used
-			case watch.Error:
-				log.Infoln("err")
-
-				// This round trip allows us to handle unstructured status
-				errObject := apierrors.FromObject(event.Object)
-				statusErr, ok := errObject.(*apierrors.StatusError)
-				if !ok {
-					log.Fatalf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
-					// Retry unknown errors
-					//return false, 0
-				}
-
-				status := statusErr.ErrStatus
-				log.Errorf("%v", status)
-
-			default:
-			}
-		}
-	}()
-
-	<-signalChan
+	// <-signalChan
 	log.Infof("Shutting down Kube-Vip")
-	for x := range sm.serviceInstances {
-		sm.serviceInstances[x].cluster.Stop()
-	}
 
 	return nil
 }


### PR DESCRIPTION
All auto-detect per namespace...

`sips whiskey`

This allows multiple `Kube-vip` in a namespace, with a leader holding the VIP and the load-balancing. In the event of maintenance or failure another will take leadership and host the VIP and load-balancing.

**TODO**: docs