### PR TITLE
Fixes panic on bad configpath

### DIFF
--- a/cmd/kube-vip-start.go
+++ b/cmd/kube-vip-start.go
@@ -50,10 +50,10 @@ var kubeVipStart = &cobra.Command{
 
 		if configPath != "" {
 			c, err := kubevip.OpenConfig(configPath)
-			startConfig = *c
 			if err != nil {
 				log.Fatalf("%v", err)
 			}
+			startConfig = *c
 		}
 
 		// parse environment variables, these will overwrite anything loaded or flags


### PR DESCRIPTION
This ensures that a bad configpath is captured and a correct error message is reported..

```
> ./kube-vip start --config ./etc/kube-vip/config.yaml                                                                    kube-vip -> panic_fix ! ? RC=1
INFO[0000] Reading configuration from [./etc/kube-vip/config.yaml]
FATA[0000] Error reading [./etc/kube-vip/config.yaml]
>
```

This fixes #38 