### PR TITLE
Finalise join command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,26 @@ demo:
 	@echo New Multi Architecture Docker image created
 	@cd ..
 
-# This is typically only for quick testing
+## Remote (push of images)
+
+# This build a local docker image (x86 only) for quick testing
 dockerx86:
 	@docker buildx build  --platform linux/amd64 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New Multi Architecture Docker image created
 
 docker:
 	@docker buildx build  --platform linux/amd64,linux/arm64,linux/arm/v7 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
+	@echo New Multi Architecture Docker image created
+
+## Local (docker load of images)
+
+# This will build a local docker image (x86 only), use make dockerLocal for all architectures
+dockerx86Local:
+	@docker buildx build  --platform linux/amd64 --load -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
+	@echo New Multi Architecture Docker image created
+
+dockerLocal:
+	@docker buildx build  --platform linux/amd64,linux/arm64,linux/arm/v7 --load -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New Multi Architecture Docker image created
 
 simplify:

--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -8,6 +8,10 @@ import (
 	"github.com/plunder-app/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // kubeadm adds two subcommands for managing a vip during a kubeadm init/join
@@ -24,19 +28,19 @@ func init() {
 	}
 	initConfig.LocalPeer = *localpeer
 	//initConfig.Peers = append(initConfig.Peers, *localpeer)
-	kubeKubeadmInit.Flags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
-	kubeKubeadmInit.Flags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP addres")
-	kubeKubeadmInit.Flags().BoolVar(&initConfig.StartAsLeader, "startAsLeader", true, "Start this instance as the cluster leader")
+	kubeKubeadm.PersistentFlags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
+	kubeKubeadm.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP addres")
+	kubeKubeadm.PersistentFlags().BoolVar(&initConfig.StartAsLeader, "startAsLeader", false, "Start this instance as the cluster leader")
 
-	kubeKubeadmInit.Flags().BoolVar(&initConfig.AddPeersAsBackends, "addPeersToLB", true, "The Virtual IP addres")
-	kubeKubeadmInit.Flags().BoolVar(&initConfig.GratuitousARP, "arp", true, "Enable Arp for Vip changes")
+	kubeKubeadm.PersistentFlags().BoolVar(&initConfig.AddPeersAsBackends, "addPeersToLB", true, "The Virtual IP addres")
+	kubeKubeadm.PersistentFlags().BoolVar(&initConfig.GratuitousARP, "arp", true, "Enable Arp for Vip changes")
 
 	// Load Balancer flags
-	kubeKubeadmInit.Flags().BoolVar(&initLoadBalancer.BindToVip, "lbBindToVip", true, "Bind example load balancer to VIP")
-	kubeKubeadmInit.Flags().StringVar(&initLoadBalancer.Type, "lbType", "tcp", "Type of load balancer instance (tcp/http)")
-	kubeKubeadmInit.Flags().StringVar(&initLoadBalancer.Name, "lbName", "Kubeadm Load Balancer", "The name of a load balancer instance")
-	kubeKubeadmInit.Flags().IntVar(&initLoadBalancer.Port, "lbPort", 6443, "Port that load balander will expose on")
-	kubeKubeadmInit.Flags().IntVar(&initLoadBalancer.BackendPort, "lbBackEndPort", 6444, "A port that all backends may be using (optional)")
+	kubeKubeadm.PersistentFlags().BoolVar(&initLoadBalancer.BindToVip, "lbBindToVip", true, "Bind example load balancer to VIP")
+	kubeKubeadm.PersistentFlags().StringVar(&initLoadBalancer.Type, "lbType", "tcp", "Type of load balancer instance (tcp/http)")
+	kubeKubeadm.PersistentFlags().StringVar(&initLoadBalancer.Name, "lbName", "Kubeadm Load Balancer", "The name of a load balancer instance")
+	kubeKubeadm.PersistentFlags().IntVar(&initLoadBalancer.Port, "lbPort", 6443, "Port that load balander will expose on")
+	kubeKubeadm.PersistentFlags().IntVar(&initLoadBalancer.BackendPort, "lbBackEndPort", 6444, "A port that all backends may be using (optional)")
 
 	kubeKubeadm.AddCommand(kubeKubeadmInit)
 	kubeKubeadm.AddCommand(kubeKubeadmJoin)
@@ -84,6 +88,68 @@ var kubeKubeadmJoin = &cobra.Command{
 		// Set the logging level for all subsequent functions
 		log.SetLevel(log.Level(logLevel))
 
+		initConfig.LoadBalancers = append(initConfig.LoadBalancers, initLoadBalancer)
+		// TODO - A load of text detailing what's actually happening
+		kubevip.ParseEnvironment(&initConfig)
+		// TODO - check for certain things VIP/interfaces
+		if initConfig.Interface == "" {
+			cmd.Help()
+			log.Fatalln("No interface is specified for kube-vip to bind to")
+		}
+
+		if initConfig.VIP == "" {
+			cmd.Help()
+			log.Fatalln("No address is specified for kube-vip to expose services on")
+		}
+
+		//if  {
+
+		// We will use kubeconfig in order to find all the master nodes
+
+		// use the current context in kubeconfig
+		config, err := clientcmd.BuildConfigFromFlags("", "/etc/kubernetes/admin.conf")
+		if err != nil {
+			panic(err.Error())
+		}
+
+		// create the clientset
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		opts := metav1.ListOptions{}
+		opts.LabelSelector = "node-role.kubernetes.io/master"
+		nodes, err := clientset.CoreV1().Nodes().List(opts)
+		//var hosts string
+		for x := range nodes.Items {
+			// Get hostname and address
+			var nodeAddress, nodeHostname string
+			for y := range nodes.Items[x].Status.Addresses {
+				switch nodes.Items[x].Status.Addresses[y].Type {
+				case corev1.NodeHostName:
+					nodeHostname = nodes.Items[x].Status.Addresses[y].Address
+				case corev1.NodeInternalIP:
+					nodeAddress = nodes.Items[x].Status.Addresses[y].Address
+				}
+			}
+
+			newPeer, err := kubevip.ParsePeerConfig(fmt.Sprintf("%s:%s:%d", nodeHostname, nodeAddress, 10000))
+			if err != nil {
+				panic(err.Error())
+			}
+			initConfig.RemotePeers = append(initConfig.RemotePeers, *newPeer)
+			//
+			//fmt.Printf("%v\n", nodes.Items[x].Status.Hostname)
+			//hosts = fmt.Sprintf("%s%s,", hosts, nodes.Items[x].Status.Addresses[0].Address)
+		}
+
+		//}
+		cfg := kubevip.GenerateManifestFromConfig(&initConfig, Release.Version)
+
+		fmt.Println(cfg)
+
+		//fmt.Printf("Found [%d] master nodes [%s]\n", len(nodes.Items), hosts)
 		// TODO - A load of text detailing what's actually happening
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.6
 	github.com/vishvananda/netlink v1.1.0
-	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 	appv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -94,6 +94,15 @@ func ParseEnvironment(c *Config) error {
 
 	// Find Start As Leader
 	// TODO - does this need depricating?
+	// Required when the host sets itself as leader before the state change
+	env = os.Getenv(vipStartLeader)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.StartAsLeader = b
+	}
 
 	// Find ARP
 	env = os.Getenv(vipArp)
@@ -287,7 +296,7 @@ func GenerateManifestFromConfig(c *Config, imageVersion string) string {
 				peers = fmt.Sprintf("%s:%s:%d", c.RemotePeers[x].ID, c.RemotePeers[x].Address, c.RemotePeers[x].Port)
 
 			}
-			peers = fmt.Sprintf("%s,%s:%s:%d", peers, c.RemotePeers[x].ID, c.RemotePeers[x].Address, c.RemotePeers[x].Port)
+			//peers = fmt.Sprintf("%s,%s:%s:%d", peers, c.RemotePeers[x].ID, c.RemotePeers[x].Address, c.RemotePeers[x].Port)
 			//fmt.Sprintf("", peers)
 		}
 		peerEnvirontment := appv1.EnvVar{

--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 var endPointIndex int // Holds the previous endpoint (for determining decisions on next endpoint)


### PR DESCRIPTION
This PR adds all of the functionality to use the kube-vip `kubeadm init` and `kubeadm join` commands. It also adds in client-go, to find all controlplane nodes.