### PR TITLE
Add multiple peers

### DIFF
--- a/pkg/packet/bgp.go
+++ b/pkg/packet/bgp.go
@@ -44,12 +44,13 @@ func BGPLookup(c *packngo.Client, k *kubevip.Config) error {
 	k.BGPConfig.RouterID = neighbours[0].CustomerIP
 	k.BGPConfig.AS = uint32(neighbours[0].CustomerAs)
 
-	// Add the peer
-	k.BGPConfig.Peers = []bgp.Peer{
-		{
-			Address: neighbours[0].PeerIps[0],
+	// Add the peer(s)
+	for x := range neighbours[0].PeerIps {
+		peer := bgp.Peer{
+			Address: neighbours[0].PeerIps[x],
 			AS:      uint32(neighbours[0].PeerAs),
-		},
+		}
+		k.BGPConfig.Peers = append(k.BGPConfig.Peers, peer)
 	}
 
 	return nil


### PR DESCRIPTION
This will add all peers found in the api to the BGP configuration.