### PR TITLE
fix garp reply msg 

### DIFF
--- a/pkg/vip/arp.go
+++ b/pkg/vip/arp.go
@@ -84,8 +84,8 @@ func gratuitousARPReply(ip net.IP, mac net.HardwareAddr) (*arpMessage, error) {
 		},
 		mac,
 		ip.To4(),
-		ethernetBroadcast,
-		net.IPv4bcast,
+		mac,
+		ip.To4(),
 	}
 
 	return m, nil

--- a/pkg/vip/arp.go
+++ b/pkg/vip/arp.go
@@ -111,9 +111,6 @@ func sendARP(iface *net.Interface, m *arpMessage) error {
 		Halen:    m.hardwareAddressLength,
 	}
 	target := ethernetBroadcast
-	if m.opcode == opARPReply {
-		target = m.targetHardwareAddress
-	}
 	for i := 0; i < len(target); i++ {
 		ll.Addr[i] = target[i]
 	}


### PR DESCRIPTION
Ref:  https://tools.ietf.org/html/rfc5944#section-4.6

A Gratuitous ARP [45] is an ARP packet sent by a node in order to
      spontaneously cause other nodes to update an entry in their ARP
      cache.  A gratuitous ARP MAY use either an ARP Request or an ARP
      Reply packet.  In either case, the ARP Sender Protocol Address and
      ARP Target Protocol Address are both set to the IP address of the
      cache entry to be updated, and the ARP Sender Hardware Address is
      set to the link-layer address to which this cache entry should be
      updated.  When using an ARP Reply packet, the Target Hardware
      Address is also set to the link-layer address to which this cache
      entry should be updated (this field is not used in an ARP Request
      packet).

Fix #80 