### PR TITLE
DNS support for kube-vip

### DIFF
--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -50,7 +50,7 @@ var kubeKubeadmInit = &cobra.Command{
 			log.Fatalln("No interface is specified for kube-vip to bind to")
 		}
 
-		if initConfig.VIP == "" {
+		if initConfig.VIP == "" && initConfig.Address == "" {
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
@@ -76,7 +76,7 @@ var kubeKubeadmJoin = &cobra.Command{
 			log.Fatalln("No interface is specified for kube-vip to bind to")
 		}
 
-		if initConfig.VIP == "" {
+		if initConfig.VIP == "" && initConfig.Address == "" {
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -54,6 +54,7 @@ func init() {
 	//initConfig.Peers = append(initConfig.Peers, *localpeer)
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP address")
+	kubeVipCmd.PersistentFlags().StringVar(&startConfig.Address, "address", "", "an address (IP or DNS name) to use as a VIP")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIPCIDR, "cidr", "", "The CIDR range for the virtual IP address")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.GratuitousARP, "arp", true, "Enable Arp for Vip changes")
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -12,14 +12,14 @@ type Cluster struct {
 	stateMachine FSM
 	stop         chan bool
 	completed    chan bool
-	network      *vip.Network
+	Network      vip.Network
 }
 
 // InitCluster - Will attempt to initialise all of the required settings for the cluster
 func InitCluster(c *kubevip.Config, disableVIP bool) (*Cluster, error) {
 
 	// TODO - Check for root (needed to netlink)
-	var network *vip.Network
+	var network vip.Network
 	var err error
 
 	if !disableVIP {
@@ -31,19 +31,23 @@ func InitCluster(c *kubevip.Config, disableVIP bool) (*Cluster, error) {
 	}
 	// Initialise the Cluster structure
 	newCluster := &Cluster{
-		network: network,
+		Network: network,
 	}
 
 	return newCluster, nil
 }
 
-func startNetworking(c *kubevip.Config) (*vip.Network, error) {
-	network, err := vip.NewConfig(c.VIP, c.Interface)
-	if err != nil {
-		// log.WithFields(log.Fields{"error": err}).Error("Network failure")
 
-		// os.Exit(-1)
+func startNetworking(c *kubevip.Config) (vip.Network, error) {
+	address := c.VIP
+
+	if c.Address != "" {
+		address = c.Address
+	}
+
+	network, err := vip.NewConfig(address, c.Interface)
+	if err != nil {
 		return nil, err
 	}
-	return &network, nil
+	return network, nil
 }

--- a/pkg/cluster/clusterRaft.go
+++ b/pkg/cluster/clusterRaft.go
@@ -87,7 +87,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 	isLeader := c.StartAsLeader
 
 	// (attempt to) Remove the virtual IP, incase it already exists
-	cluster.network.DeleteIP()
+	cluster.Network.DeleteIP()
 
 	// leader log broadcast - this counter is used to stop flooding STDOUT with leader log entries
 	var leaderbroadcast int
@@ -132,7 +132,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 					// Re-broadcast arp to ensure network stays up to date
 					if c.GratuitousARP == true {
 						// Gratuitous ARP, will broadcast to new MAC <-> IP
-						err = vip.ARPSendGratuitous(c.VIP, c.Interface)
+						err = vip.ARPSendGratuitous(cluster.Network.IP(), c.Interface)
 						if err != nil {
 							log.Warnf("%v", err)
 						}
@@ -143,7 +143,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 					}
 				} else {
 					// (attempt to) Remove the virtual IP, incase it already exists to keep nodes clean
-					cluster.network.DeleteIP()
+					cluster.Network.DeleteIP()
 					isLeader = false
 				}
 
@@ -157,7 +157,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 					isLeader = true
 
 					log.Info("This node is assuming leadership of the cluster")
-					err = cluster.network.AddIP()
+					err = cluster.Network.AddIP()
 					if err != nil {
 						log.Warnf("%v", err)
 					}
@@ -167,7 +167,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 					for x := range c.LoadBalancers {
 
 						if c.LoadBalancers[x].BindToVip == true {
-							err = VipLB.Add(c.VIP, &c.LoadBalancers[x])
+							err = VipLB.Add(cluster.Network.IP(), &c.LoadBalancers[x])
 							if err != nil {
 								log.Warnf("Error creating loadbalancer [%s] type [%s] -> error [%s]", c.LoadBalancers[x].Name, c.LoadBalancers[x].Type, err)
 								log.Errorf("Dropping Leadership to another node in the cluster")
@@ -179,7 +179,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 									log.Warnf("%v", err)
 								}
 
-								err = cluster.network.DeleteIP()
+								err = cluster.Network.DeleteIP()
 								if err != nil {
 									log.Warnf("%v", err)
 								}
@@ -189,7 +189,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 
 					if c.GratuitousARP == true {
 						// Gratuitous ARP, will broadcast to new MAC <-> IP
-						err = vip.ARPSendGratuitous(c.VIP, c.Interface)
+						err = vip.ARPSendGratuitous(cluster.Network.IP(), c.Interface)
 						if err != nil {
 							log.Warnf("%v", err)
 						}
@@ -205,7 +205,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 						log.Warnf("%v", err)
 					}
 
-					err = cluster.network.DeleteIP()
+					err = cluster.Network.DeleteIP()
 					if err != nil {
 						log.Warnf("%v", err)
 					}
@@ -215,15 +215,15 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 
 				if isLeader {
 
-					result, err := cluster.network.IsSet()
+					result, err := cluster.Network.IsSet()
 					if err != nil {
-						log.WithFields(log.Fields{"error": err, "ip": cluster.network.IP(), "interface": cluster.network.Interface()}).Error("Could not check ip")
+						log.WithFields(log.Fields{"error": err, "ip": cluster.Network.IP(), "interface": cluster.Network.Interface()}).Error("Could not check ip")
 					}
 
 					if result == false {
 						log.Error("This node is leader and is adopting the virtual IP")
 
-						err = cluster.network.AddIP()
+						err = cluster.Network.AddIP()
 						if err != nil {
 							log.Warnf("%v", err)
 						}
@@ -232,7 +232,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 						for x := range c.LoadBalancers {
 
 							if c.LoadBalancers[x].BindToVip == true {
-								err = VipLB.Add(c.VIP, &c.LoadBalancers[x])
+								err = VipLB.Add(cluster.Network.IP(), &c.LoadBalancers[x])
 								if err != nil {
 									log.Warnf("Error creating loadbalancer [%s] type [%s] -> error [%s]", c.LoadBalancers[x].Name, c.LoadBalancers[x].Type, err)
 								}
@@ -240,7 +240,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 						}
 						if c.GratuitousARP == true {
 							// Gratuitous ARP, will broadcast to new MAC <-> IP
-							err = vip.ARPSendGratuitous(c.VIP, c.Interface)
+							err = vip.ARPSendGratuitous(cluster.Network.IP(), c.Interface)
 							if err != nil {
 								log.Warnf("%v", err)
 							}
@@ -266,7 +266,7 @@ func (cluster *Cluster) StartRaftCluster(c *kubevip.Config) error {
 
 				if isLeader {
 					log.Info("[VIP] Releasing the Virtual IP")
-					err = cluster.network.DeleteIP()
+					err = cluster.Network.DeleteIP()
 					if err != nil {
 						log.Warnf("%v", err)
 					}

--- a/pkg/cluster/singleNode.go
+++ b/pkg/cluster/singleNode.go
@@ -37,12 +37,12 @@ func (cluster *Cluster) StartSingleNode(c *kubevip.Config, disableVIP bool) erro
 	}
 
 	if !disableVIP {
-		err := cluster.network.DeleteIP()
+		err := cluster.Network.DeleteIP()
 		if err != nil {
 			log.Warnf("Attempted to clean existing VIP => %v", err)
 		}
 
-		err = cluster.network.AddIP()
+		err = cluster.Network.AddIP()
 		if err != nil {
 			log.Warnf("%v", err)
 		}
@@ -51,7 +51,7 @@ func (cluster *Cluster) StartSingleNode(c *kubevip.Config, disableVIP bool) erro
 		for x := range c.LoadBalancers {
 
 			if c.LoadBalancers[x].BindToVip == true {
-				err = VipLB.Add(c.VIP, &c.LoadBalancers[x])
+				err = VipLB.Add(cluster.Network.IP(), &c.LoadBalancers[x])
 				if err != nil {
 					log.Warnf("Error creating loadbalancer [%s] type [%s] -> error [%s]", c.LoadBalancers[x].Name, c.LoadBalancers[x].Type, err)
 				}
@@ -61,7 +61,7 @@ func (cluster *Cluster) StartSingleNode(c *kubevip.Config, disableVIP bool) erro
 
 	if c.GratuitousARP == true {
 		// Gratuitous ARP, will broadcast to new MAC <-> IP
-		err := vip.ARPSendGratuitous(c.VIP, c.Interface)
+		err := vip.ARPSendGratuitous(cluster.Network.IP(), c.Interface)
 		if err != nil {
 			log.Warnf("%v", err)
 		}
@@ -88,7 +88,7 @@ func (cluster *Cluster) StartSingleNode(c *kubevip.Config, disableVIP bool) erro
 				if !disableVIP {
 
 					log.Info("[VIP] Releasing the Virtual IP")
-					err = cluster.network.DeleteIP()
+					err = cluster.Network.DeleteIP()
 					if err != nil {
 						log.Warnf("%v", err)
 					}

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -555,12 +555,12 @@ func generatePodSpec(c *Config, imageVersion string) *corev1.Pod {
 	}
 
 	if c.Address != "" {
-		newEnvironment = append(newEnvironment, appv1.EnvVar{
+		newEnvironment = append(newEnvironment, corev1.EnvVar{
 			Name:  address,
 			Value: c.Address,
 		})
 	} else {
-		newEnvironment = append(newEnvironment, appv1.EnvVar{
+		newEnvironment = append(newEnvironment, corev1.EnvVar{
 			Name:  vipAddress,
 			Value: c.VIP,
 		})

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -37,10 +37,16 @@ const (
 	vipInterface = "vip_interface"
 
 	//vipAddress - defines the address that the vip will expose
+	// DEPRECATED: will be removed in a next release
 	vipAddress = "vip_address"
 
 	//vipCidr - defines the cidr that the vip will use
 	vipCidr = "vip_cidr"
+
+	//address - defines the address that would be used as a vip
+	// it may be an IP or a DNS name, in case of a DNS name
+	// kube-vip will try to resolve it and use the IP as a VIP
+	address = "address"
 
 	//vipSingleNode - defines the vip start as a single node cluster
 	vipSingleNode = "vip_singlenode"
@@ -155,6 +161,8 @@ func ParseEnvironment(c *Config) error {
 	if env != "" {
 		// TODO - parse address net.Host()
 		c.VIP = env
+	} else {
+		c.Address = os.Getenv(address)
 	}
 
 	// Find vip address cidr range
@@ -399,10 +407,6 @@ func generatePodSpec(c *Config, imageVersion string) *corev1.Pod {
 			Name:  vipInterface,
 			Value: c.Interface,
 		},
-		{
-			Name:  vipAddress,
-			Value: c.VIP,
-		},
 	}
 
 	// If a CIDR is used add it to the manifest
@@ -548,6 +552,18 @@ func generatePodSpec(c *Config, imageVersion string) *corev1.Pod {
 		}
 
 		newEnvironment = append(newEnvironment, lb...)
+	}
+
+	if c.Address != "" {
+		newEnvironment = append(newEnvironment, appv1.EnvVar{
+			Name:  address,
+			Value: c.Address,
+		})
+	} else {
+		newEnvironment = append(newEnvironment, appv1.EnvVar{
+			Name:  vipAddress,
+			Value: c.VIP,
+		})
 	}
 
 	// Parse peers into a comma seperated string

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -27,6 +27,9 @@ type Config struct {
 	// VIPCIDR is cidr range for the VIP (primarily needed for BGP)
 	VIPCIDR string `yaml:"vipCidr"`
 
+	// Address is the IP or DNS Name to use as a VirtualIP
+	Address string `yaml:"address"`
+
 	// GratuitousARP will broadcast an ARP update when the VIP changes host
 	GratuitousARP bool `yaml:"gratuitousARP"`
 

--- a/pkg/vip/dns.go
+++ b/pkg/vip/dns.go
@@ -13,8 +13,6 @@ type IPUpdater interface {
 }
 
 type ipUpdater struct {
-	// TODO: cache the latest entry to be able to update
-	// in case of lookup failures
 	dnsName string
 	vip     Network
 }
@@ -37,9 +35,11 @@ func (d *ipUpdater) Run(ctx context.Context) {
 			default:
 				ip, err := lookupHost(d.dnsName)
 				if err != nil {
-					log.Errorf("cannot lookup %s: %v", d.dnsName, err)
-					continue
+					log.Warnf("cannot lookup %s: %v", d.dnsName, err)
+					// fallback to renewing the existing IP
+					ip = d.vip.IP()
 				}
+
 				log.Infof("setting %s as an IP", ip)
 				d.vip.SetIP(ip)
 				d.vip.AddIP()

--- a/pkg/vip/dns.go
+++ b/pkg/vip/dns.go
@@ -1,0 +1,51 @@
+package vip
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// IPUpdater is the interface to plug dns updaters
+type IPUpdater interface {
+	Run(ctx context.Context)
+}
+
+type ipUpdater struct {
+	// TODO: cache the latest entry to be able to update
+	// in case of lookup failures
+	dnsName string
+	vip     Network
+}
+
+// NewIPUpdater creates a DNSUpdater
+func NewIPUpdater(dnsName string, vip Network) IPUpdater {
+	return &ipUpdater{
+		dnsName: dnsName,
+		vip:     vip,
+	}
+}
+
+// Run runs the IP updater
+func (d *ipUpdater) Run(ctx context.Context) {
+	go func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				ip, err := lookupHost(d.dnsName)
+				if err != nil {
+					log.Errorf("cannot lookup %s: %v", d.dnsName, err)
+					continue
+				}
+				log.Infof("setting %s as an IP", ip)
+				d.vip.SetIP(ip)
+				d.vip.AddIP()
+
+			}
+			time.Sleep(3 * time.Second)
+		}
+	}(ctx)
+}

--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -1,0 +1,24 @@
+package vip
+
+import (
+	"net"
+	"github.com/pkg/errors"
+)
+
+// LookupHost resolves dnsName and return an IP or an error
+func lookupHost(dnsName string) (string, error) {
+	addrs, err := net.LookupHost(dnsName)
+	if err != nil {
+		return "", err
+	}
+	if len(addrs) == 0 {
+		return "", errors.Errorf("empty address for %s", dnsName)
+	}
+	return addrs[0], nil
+}
+
+// IsIP returns if address is an IP or not
+func IsIP(address string) bool {
+	ip := net.ParseIP(address)
+	return ip != nil
+}


### PR DESCRIPTION
This PR fixes #79 and enables DNS support through an `address` flag/env/config. `vip_address` should is deprecated but will continue to work.

`address` accepts a DNS name or an IP, kube-vip will now run an IP updater that resolves the DNS Name and update the IP, this one will have a validity time, so that we don't have to care about cleanup whenever there is a DNS record update.
One thing small thing that is left to do is to cache the latest response in the `ipUpdater` struct so that we're able to update the IP in case of lookup failures.

Lastly, I will raise an issue to start refactoring our code base, so that we're able to introduce unit and integration tests