### PR TITLE
kubeadm init should generate pod spec

### DIFF
--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -54,7 +54,7 @@ var kubeKubeadmInit = &cobra.Command{
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
-		cfg := kubevip.GenerateDeamonsetManifestFromConfig(&initConfig, Release.Version)
+		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version)
 
 		fmt.Println(cfg)
 	},


### PR DESCRIPTION
The `kube-vip kubeadm init` should generate a pod spec, it's accidentally generating a daemonset spec. This fixes it.