### PR TITLE
This adds upnp functionality to kube-vip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.2.0
+VERSION := 0.2.1
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)
@@ -54,10 +54,12 @@ demo:
 
 # This build a local docker image (x86 only) for quick testing
 dockerx86:
+	@rm ./kube-vip
 	@docker buildx build  --platform linux/amd64 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New single x86 Architecture Docker image created
 
 docker:
+	@rm ./kube-vip
 	@docker buildx build  --platform linux/amd64,linux/arm64,linux/arm/v7 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New Multi Architecture Docker image created
 
@@ -65,10 +67,12 @@ docker:
 
 # This will build a local docker image (x86 only), use make dockerLocal for all architectures
 dockerx86Local:
+	@rm ./kube-vip
 	@docker buildx build  --platform linux/amd64 --load -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New Multi Architecture Docker image created
 
 dockerLocal:
+	@rm ./kube-vip
 	@docker buildx build  --platform linux/amd64,linux/arm64,linux/arm/v7 --load -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New Multi Architecture Docker image created
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/hashicorp/raft v1.1.2
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/k-sone/critbitgo v1.4.0 // indirect
+	github.com/kamhlos/upnp v0.0.0-20171112074648-2713e75d9aef
 	github.com/magiconair/properties v1.8.3 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 // indirect

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/k-sone/critbitgo v1.3.1-0.20191024122315-48c9e1530131 h1:2bjzgZk4GiWA
 github.com/k-sone/critbitgo v1.3.1-0.20191024122315-48c9e1530131/go.mod h1:7E6pyoyADnFxlUBEKcnfS49b7SUAQGMK+OAp/UQvo0s=
 github.com/k-sone/critbitgo v1.4.0 h1:l71cTyBGeh6X5ATh6Fibgw3+rtNT80BA0uNNWgkPrbE=
 github.com/k-sone/critbitgo v1.4.0/go.mod h1:7E6pyoyADnFxlUBEKcnfS49b7SUAQGMK+OAp/UQvo0s=
+github.com/kamhlos/upnp v0.0.0-20171112074648-2713e75d9aef h1:hYYYR5sSbR211XTKlIERN7I7xYU1D47eft2ooDg0Dtg=
+github.com/kamhlos/upnp v0.0.0-20171112074648-2713e75d9aef/go.mod h1:0L/S1RSG4wA4M2Vhau3z7VsYMLxFnsX0bzzgwYRIdYU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
With upnp functionality enabled any loadbalancer will be exposed through a upnp gateway! Fixes #58 

Finally worked it out!

**Enabled UPNP in `kube-vip` manifest:**
```
        env:
          - name: enableUPNP
            value: "true"
```

**Expose a service:**

```
dan@k8s01:~$ k expose deployment nginx-deployment --port=32380 --target-port=80 --type=LoadBalancer --name=nginx-loadbalance
service/nginx-loadbalance exposed
dan@k8s01:~$ k get svc
NAME                TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)           AGE
kubernetes          ClusterIP      10.96.0.1        <none>          443/TCP           21h
nginx-loadbalance   LoadBalancer   10.110.170.214   192.168.0.201   32380:32479/TCP   3s
```

**Check upnp logs on router:**
```
$ cat /var/log/upnp.leases | grep nginx
TCP:32380:192.168.0.201:32380:0:nginx-loadbalance
```

**Test from outside world:**
```
$ curl <external_ip>:32380
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
```

cc/ @displague