### PR TITLE
LoadBalancer Service changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.2.0
+VERSION := 0.2.1
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/pkg/cluster/singleNode.go
+++ b/pkg/cluster/singleNode.go
@@ -102,7 +102,7 @@ func (cluster *Cluster) StartSingleNode(c *kubevip.Config, disableVIP bool) erro
 	return nil
 }
 
-// StartLoadBalancerService will start a VIP/LoadBalancer instance
+// StartLoadBalancerService will start a VIP instance and leave it for kube-proxy to handle
 func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, disableVIP bool) error {
 	// Start a kube-vip loadbalancer service
 	log.Infoln("Starting kube-vip as a LoadBalancer Service")

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -217,7 +217,7 @@ func (sm *Manager) syncServices(s *plndrServices) error {
 				log.Errorf("Failed to add Service [%s] / [%s]", s.Services[x].ServiceName, s.Services[x].UID)
 				return err
 			}
-			err = c.StartSingleNode(&newService.vipConfig, false)
+			err = c.StartLoadBalancerService(&newService.vipConfig, false)
 			if err != nil {
 				log.Errorf("Failed to add Service [%s] / [%s]", s.Services[x].ServiceName, s.Services[x].UID)
 				return err

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -143,7 +143,7 @@ func (sm *Manager) syncServices(s *plndrServices) error {
 							log.Errorf("Failed to add Service [%s] / [%s]", newService.service.ServiceName, newService.service.UID)
 							//return err
 						}
-						err = c.StartSingleNode(&newService.vipConfig, false)
+						err = c.StartLoadBalancerService(&newService.vipConfig, false)
 						if err != nil {
 							log.Errorf("Failed to add Service [%s] / [%s]", newService.service.ServiceName, newService.service.UID)
 							//return err


### PR DESCRIPTION
This removes the TCP LoadBalancer from the path and leaves it up to `kube-proxy` to handle the requests.