### PR TITLE
BGP Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.2.1
+VERSION := 0.2.2
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -46,6 +46,11 @@ func (sm *Manager) deleteService(uid string) error {
 				}
 				netlink.LinkDel(macvlan)
 			}
+			if sm.serviceInstances[x].vipConfig.EnableBGP {
+				cidrVip := fmt.Sprintf("%s/%s", sm.serviceInstances[x].vipConfig.VIP, sm.serviceInstances[x].vipConfig.VIPCIDR)
+				err := sm.bgpServer.DelHost(cidrVip)
+				return err
+			}
 		}
 	}
 	// If we've been through all services and not found the correct one then error


### PR DESCRIPTION
This adds the following:

`bgp_routerinterface` can be used to look up an address to advertise from

```
          - name: bgp_routerinterface
            value: "ens160"
```

Also fixes the removal of BGP routes when a service is deleted.