### PR TITLE
Interface scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.2.1
+VERSION := 0.2.2
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -53,10 +53,10 @@ func init() {
 	//initConfig.Peers = append(initConfig.Peers, *localpeer)
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP address")
-	kubeVipCmd.PersistentFlags().StringVar(&startConfig.Address, "address", "", "an address (IP or DNS name) to use as a VIP")
-	kubeVipCmd.PersistentFlags().IntVar(&startConfig.Port, "port", 6443, "listen port for the VIP")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Address, "address", "", "an address (IP or DNS name) to use as a VIP")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.Port, "port", 6443, "listen port for the VIP")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIPCIDR, "cidr", "32", "The CIDR range for the virtual IP address")
-	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableARP, "arp", true, "Enable Arp for Vip changes")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableARP, "arp", false, "Enable Arp for Vip changes")
 
 	// Clustering type (leaderElection)
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableLeaderElection, "leaderElection", false, "Use the Kubernetes leader election mechanism for clustering")
@@ -142,7 +142,7 @@ var kubeVipService = &cobra.Command{
 		log.SetLevel(log.Level(logLevel))
 
 		// parse environment variables, these will overwrite anything loaded or flags
-		err := kubevip.ParseEnvironment(&startConfig)
+		err := kubevip.ParseEnvironment(&initConfig)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -155,7 +155,7 @@ var kubeVipService = &cobra.Command{
 		}
 
 		// Define the new service manager
-		mgr, err := service.NewManager(configMap, &startConfig)
+		mgr, err := service.NewManager(configMap, &initConfig)
 		if err != nil {
 			log.Fatalf("%v", err)
 		}

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -55,7 +55,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP address")
 	kubeVipCmd.PersistentFlags().StringVar(&startConfig.Address, "address", "", "an address (IP or DNS name) to use as a VIP")
 	kubeVipCmd.PersistentFlags().IntVar(&startConfig.Port, "port", 6443, "listen port for the VIP")
-	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIPCIDR, "cidr", "", "The CIDR range for the virtual IP address")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIPCIDR, "cidr", "32", "The CIDR range for the virtual IP address")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableARP, "arp", true, "Enable Arp for Vip changes")
 
 	// Clustering type (leaderElection)

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -122,11 +122,13 @@ func (sm *Manager) Start() error {
 
 	// If BGP is enabled then we start a server instance that will broadcast VIPs
 	if sm.config.EnableBGP {
+		log.Infoln("Starting loadBalancer Service with the BGP engine")
 		return sm.startBGP()
 	}
 
 	// If ARP is enabled then we start a LeaderElection that will use ARP to advertise VIPs
 	if sm.config.EnableARP {
+		log.Infoln("Starting loadBalancer Service with the ARP engine")
 		return sm.startARP()
 	}
 

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -46,6 +46,11 @@ func (sm *Manager) deleteService(uid string) error {
 				}
 				netlink.LinkDel(macvlan)
 			}
+			if sm.serviceInstances[x].vipConfig.EnableBGP {
+				cidrVip := fmt.Sprintf("%s/%s", sm.serviceInstances[x].vipConfig.VIP, sm.serviceInstances[x].vipConfig.VIPCIDR)
+				err := sm.bgpServer.DelHost(cidrVip)
+				return err
+			}
 		}
 	}
 	// If we've been through all services and not found the correct one then error

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -50,6 +51,10 @@ func NewConfig(address string, iface string, isDDNS bool) (Network, error) {
 		result.address, err = netlink.ParseAddr(address + "/32")
 		if err != nil {
 			return result, errors.Wrapf(err, "could not parse address '%s'", address)
+		}
+		// Ensure we don't have a global address on loopback
+		if iface == "lo" {
+			result.address.Scope = unix.RT_SCOPE_HOST
 		}
 		return result, nil
 	}


### PR DESCRIPTION
This ensures that addresses attached to localhost `lo` can't proliferate and be picked up by things such as `kubelet`.