### PR TITLE
Fixes to manifest gen

### DIFF
--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -43,7 +43,8 @@ var kubeManifestPod = &cobra.Command{
 			log.Fatalln("No interface is specified for kube-vip to bind to")
 		}
 
-		if initConfig.VIP == "" {
+		// The control plane has a requirement for a VIP being specified
+		if initConfig.EnableControlPane && initConfig.VIP == "" {
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
@@ -68,7 +69,8 @@ var kubeManifestDaemon = &cobra.Command{
 			log.Fatalln("No interface is specified for kube-vip to bind to")
 		}
 
-		if initConfig.VIP == "" {
+		// The control plane has a requirement for a VIP being specified
+		if initConfig.EnableControlPane && initConfig.VIP == "" {
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}


### PR DESCRIPTION
This ensures that we only check for a VIP if the control-plane is enabled.