### PR TITLE
Manifest for inCluster

### DIFF
--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -54,7 +54,7 @@ var kubeKubeadmInit = &cobra.Command{
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
-		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version)
+		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version, inCluster)
 
 		fmt.Println(cfg)
 	},
@@ -123,7 +123,7 @@ var kubeKubeadmJoin = &cobra.Command{
 
 		}
 		// Generate manifest and print
-		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version)
+		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version, inCluster)
 		fmt.Println(cfg)
 	},
 }

--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -13,7 +13,11 @@ import (
 // - Pod spec manifest, mainly used for a static pod (kubeadm)
 // - Daemonset manifest, mainly used to run kube-vip as a deamonset within Kubernetes (k3s/rke)
 
+//var inCluster bool
+
 func init() {
+	kubeManifestPod.PersistentFlags().BoolVar(&inCluster, "inCluster", false, "Use the incluster token to authenticate to Kubernetes")
+	kubeManifestDaemon.PersistentFlags().BoolVar(&inCluster, "inCluster", false, "Use the incluster token to authenticate to Kubernetes")
 
 	kubeManifest.AddCommand(kubeManifestPod)
 	kubeManifest.AddCommand(kubeManifestDaemon)
@@ -48,7 +52,7 @@ var kubeManifestPod = &cobra.Command{
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
-		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version)
+		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version, inCluster)
 
 		fmt.Println(cfg)
 	},
@@ -74,7 +78,7 @@ var kubeManifestDaemon = &cobra.Command{
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
-		cfg := kubevip.GenerateDeamonsetManifestFromConfig(&initConfig, Release.Version)
+		cfg := kubevip.GenerateDeamonsetManifestFromConfig(&initConfig, Release.Version, inCluster)
 
 		fmt.Println(cfg)
 	},

--- a/pkg/packet/utils.go
+++ b/pkg/packet/utils.go
@@ -1,6 +1,9 @@
 package packet
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/packethost/packngo"
@@ -33,4 +36,23 @@ func findSelf(c *packngo.Client, projectID string) *packngo.Device {
 		}
 	}
 	return nil
+}
+
+func GetPacketConfig(providerConfig string) (string, string, error) {
+	var config struct {
+		AuthToken string `json:"apiKey"`
+		ProjectID string `json:"projectId"`
+	}
+	// get our token and project
+	if providerConfig != "" {
+		configBytes, err := ioutil.ReadFile(providerConfig)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get read configuration file at path %s: %v", providerConfig, err)
+		}
+		err = json.Unmarshal(configBytes, &config)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to process json of configuration file at path %s: %v", providerConfig, err)
+		}
+	}
+	return config.AuthToken, config.ProjectID, nil
 }


### PR DESCRIPTION
This allows a user to use the `--inCluster` flag and ensure that the generated manifest won't include the volumeMount for the external kubeConfig.