### PR TITLE
Enables BGP multihop

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -99,6 +99,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.BGPPeerConfig.Address, "peerAddress", "", "The address of a BGP peer")
 	kubeVipCmd.PersistentFlags().Uint32Var(&initConfig.BGPPeerConfig.AS, "peerAS", 65000, "The AS number for a BGP peer")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.BGPPeerConfig.Password, "peerPass", "", "The md5 password for a BGP peer")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.BGPPeerConfig.MultiHop, "multihop", false, "This will enable BGP multihop support")
 
 	// Control plane specific flags
 	kubeVipCmd.PersistentFlags().StringVarP(&initConfig.Namespace, "namespace", "n", "kube-system", "The configuration map defined within the cluster")

--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -37,6 +37,12 @@ func (b *Server) AddPeer(peer Peer) (err error) {
 			},
 		},
 
+		// This enables routes to be sent to routers across multiple hops
+		EbgpMultihop: &api.EbgpMultihop{
+			Enabled:     peer.MultiHop,
+			MultihopTtl: 50,
+		},
+
 		Transport: &api.Transport{
 			MtuDiscovery:  true,
 			RemoteAddress: peer.Address,

--- a/pkg/bgp/types.go
+++ b/pkg/bgp/types.go
@@ -7,6 +7,7 @@ type Peer struct {
 	Address  string
 	AS       uint32
 	Password string
+	MultiHop bool
 }
 
 // Config defines the BGP server configuration

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -94,6 +94,8 @@ const (
 	bgpPeerAS = "bgp_peeras"
 	//bgpPeerAS defines the AS for a BGP peer
 	bgpPeerPassword = "bgp_peerpass"
+	//bgpMultiHop enables mulithop routing
+	bgpMultiHop = "bgp_multihop"
 
 	//cpNamespace defines the namespace the control plane pods will run in
 	cpNamespace = "cp_namespace"
@@ -376,6 +378,16 @@ func ParseEnvironment(c *Config) error {
 		c.BGPPeerConfig.AS = uint32(u64)
 	}
 
+	// BGP Peer mutlihop
+	env = os.Getenv(bgpMultiHop)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.BGPPeerConfig.MultiHop = b
+	}
+
 	// BGP Peer password
 	env = os.Getenv(bgpPeerPassword)
 	if env != "" {
@@ -648,6 +660,10 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			{
 				Name:  bgpPeerAddress,
 				Value: c.BGPPeerConfig.Address,
+			},
+			{
+				Name:  bgpMultiHop,
+				Value: strconv.FormatBool(c.BGPPeerConfig.MultiHop),
 			},
 			{
 				Name:  bgpPeerPassword,


### PR DESCRIPTION
The `--multihop` flag will enable BGP multi hop to BGP peers.