### PR TITLE
Now uses projectID from env/cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,8 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
     CGO_ENABLED=0 GOOS=linux make build
 
 FROM scratch
+# Add Certificates into the image, for anything that does API calls
+COPY --from=dev /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Add kube-vip binary
 COPY --from=dev /src/kube-vip /
 ENTRYPOINT ["/kube-vip"]

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -82,6 +82,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnablePacket, "packet", false, "This will use the Packet API (requires the token ENV) to update the EIP <-> VIP")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PacketAPIKey, "packetKey", "", "The API token for authenticating with the Packet API")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PacketProject, "packetProject", "", "The name of project already created within Packet")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PacketProjectID, "packetProjectID", "", "The ID of project already created within Packet")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ProviderConfig, "provider-config", "", "The path to a provider configuration")
 
 	// Load Balancer flags

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,7 @@ github.com/osrg/gobgp v0.0.0-20191101114856-a42a1a5f6bf0 h1:sqWev+JAbQevLXYorfyT
 github.com/osrg/gobgp v0.0.0-20191101114856-a42a1a5f6bf0/go.mod h1:IVw8wEHROhX0qrmI8c6j3N8EDXZSC4YkktSzkX/JZ8Q=
 github.com/packethost/packngo v0.5.0 h1:WGpfeRMstPqgyXGUXl6b9xFsbUudXU3p0+JlYri290U=
 github.com/packethost/packngo v0.5.0/go.mod h1:aRxUEV1TprXVcWr35v8tNYgZMjv7FHaInXx224vF2fc=
+github.com/packethost/packngo v0.5.1 h1:y+jWcMnyArP3hVZRsBkAXTLhokuqdYg6JUmkshX2SMk=
 github.com/packethost/packngo v0.5.1/go.mod h1:aRxUEV1TprXVcWr35v8tNYgZMjv7FHaInXx224vF2fc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=

--- a/pkg/cluster/clusterLeader.go
+++ b/pkg/cluster/clusterLeader.go
@@ -161,7 +161,7 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 		// We're using Packet with BGP, popuplate the Peer information from the API
 		if c.EnableBGP {
 			log.Infoln("Looking up the BGP configuration from packet")
-			err = packet.BGPLookup(packetClient, c, "") //TODO: This will need looking at in the future
+			err = packet.BGPLookup(packetClient, c)
 			if err != nil {
 				log.Error(err)
 			}

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -77,8 +77,11 @@ const (
 	//vipPacket defines that the packet API will be used for EIP
 	vipPacket = "vip_packet"
 
-	//vipPacket defines which project within Packet to use
+	//vipPacketProject defines which project within Packet to use
 	vipPacketProject = "vip_packetproject"
+
+	//vipPacketProjectID defines which projectID within Packet to use
+	vipPacketProjectID = "vip_packetprojectid"
 
 	//providerConfig defines a path to a configuration that should be parsed
 	providerConfig = "provider_config"
@@ -427,6 +430,13 @@ func ParseEnvironment(c *Config) error {
 		c.PacketProject = env
 	}
 
+	// Find the Packet project ID
+	env = os.Getenv(vipPacketProjectID)
+	if env != "" {
+		// TODO - parse address net.Host()
+		c.PacketProjectID = env
+	}
+
 	// Enable the load-balancer
 	env = os.Getenv(lbEnable)
 	if env != "" {
@@ -651,6 +661,10 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			{
 				Name:  vipPacketProject,
 				Value: c.PacketProject,
+			},
+			{
+				Name:  vipPacketProjectID,
+				Value: c.PacketProjectID,
 			},
 			{
 				Name:  "PACKET_AUTH_TOKEN",

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -76,6 +76,9 @@ type Config struct {
 	// PacketProject, is the name of a particular defined project
 	PacketProject string
 
+	// PacketProjectID, is the name of a particular defined project
+	PacketProjectID string
+
 	// ProviderConfig, is the path to a provider configuration file
 	ProviderConfig string
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -146,15 +146,15 @@ func (sm *Manager) Start() error {
 
 	// If BGP is enabled then we start a server instance that will broadcast VIPs
 	if sm.config.EnableBGP {
-		log.Infoln("Starting Kube-vip loadBalancer Service with the BGP engine")
-		log.Infof("Namespace [%s], Hybrid mode [%t]", sm.config.Namespace, sm.config.EnableControlPane)
+		log.Infoln("Starting Kube-vip Manager with the BGP engine")
+		log.Infof("Namespace [%s], Hybrid mode [%t]", sm.config.Namespace, sm.config.EnableControlPane && sm.config.EnableServices)
 		return sm.startBGP()
 	}
 
 	// If ARP is enabled then we start a LeaderElection that will use ARP to advertise VIPs
 	if sm.config.EnableARP {
-		log.Infoln("Starting loadBalancer Service with the ARP engine")
-		log.Infof("Namespace [%s], Hybrid mode [%t]", sm.config.Namespace, sm.config.EnableControlPane)
+		log.Infoln("Starting Kube-vip Manager with the ARP engine")
+		log.Infof("Namespace [%s], Hybrid mode [%t]", sm.config.Namespace, sm.config.EnableControlPane && sm.config.EnableServices)
 		return sm.startARP()
 	}
 

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -21,7 +21,6 @@ func (sm *Manager) startBGP() error {
 	// If Packet is enabled then we can begin our preperation work
 	var packetClient *packngo.Client
 	if sm.config.EnablePacket {
-		var projectID string
 		if sm.config.ProviderConfig != "" {
 			key, project, err := packet.GetPacketConfig(sm.config.ProviderConfig)
 			if err != nil {
@@ -30,7 +29,7 @@ func (sm *Manager) startBGP() error {
 				// Set the environment variable with the key for the project
 				os.Setenv("PACKET_AUTH_TOKEN", key)
 				// Update the configuration with the project key
-				projectID = project
+				sm.config.PacketProjectID = project
 			}
 		}
 		packetClient, err = packngo.NewClient()
@@ -41,7 +40,7 @@ func (sm *Manager) startBGP() error {
 		// We're using Packet with BGP, popuplate the Peer information from the API
 		if sm.config.EnableBGP {
 			log.Infoln("Looking up the BGP configuration from packet")
-			err = packet.BGPLookup(packetClient, sm.config, projectID)
+			err = packet.BGPLookup(packetClient, sm.config)
 			if err != nil {
 				log.Error(err)
 			}

--- a/pkg/packet/bgp.go
+++ b/pkg/packet/bgp.go
@@ -10,16 +10,16 @@ import (
 )
 
 // BGPLookup will use the Packet API functions to populate the BGP information
-func BGPLookup(c *packngo.Client, k *kubevip.Config, projectID string) error {
+func BGPLookup(c *packngo.Client, k *kubevip.Config) error {
 	var thisDevice *packngo.Device
-	if projectID == "" {
+	if k.PacketProjectID == "" {
 		proj := findProject(k.PacketProject, c)
 		if proj == nil {
 			return fmt.Errorf("Unable to find Project [%s]", k.PacketProject)
 		}
 		thisDevice = findSelf(c, proj.ID)
 	} else {
-		thisDevice = findSelf(c, projectID)
+		thisDevice = findSelf(c, k.PacketProjectID)
 	}
 	if thisDevice == nil {
 		return fmt.Errorf("Unable to find local/this device in packet API")

--- a/pkg/service/manager_bgp.go
+++ b/pkg/service/manager_bgp.go
@@ -30,7 +30,7 @@ func (sm *Manager) startBGP() error {
 		// We're using Packet with BGP, popuplate the Peer information from the API
 		if sm.config.EnableBGP {
 			log.Infoln("Looking up the BGP configuration from packet")
-			err = packet.BGPLookup(packetClient, sm.config, "") // TODO: This will need looking at in the future
+			err = packet.BGPLookup(packetClient, sm.config)
 			if err != nil {
 				log.Error(err)
 			}


### PR DESCRIPTION
This adds the capability for using a `projectID` instead of `projectName`... It also adds the capability for the ca-certs to exist inside the scratch container.