### PR TITLE
Adds multiple peers from manifest

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -101,6 +101,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().Uint32Var(&initConfig.BGPPeerConfig.AS, "peerAS", 65000, "The AS number for a BGP peer")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.BGPPeerConfig.Password, "peerPass", "", "The md5 password for a BGP peer")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.BGPPeerConfig.MultiHop, "multihop", false, "This will enable BGP multihop support")
+	kubeVipCmd.PersistentFlags().StringSliceVar(&initConfig.BGPPeers, "bgppeers", []string{"192.168.0.2:65000:password:true", "192.168.0.3:65000:password:true"}, "Comma seperated BGP Peer, format: address:as:password:multihop")
 
 	// Control plane specific flags
 	kubeVipCmd.PersistentFlags().StringVarP(&initConfig.Namespace, "namespace", "n", "kube-system", "The configuration map defined within the cluster")

--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -104,3 +104,37 @@ func (b *Server) getPath(ip net.IP) *api.Path {
 		Pattrs: []*any.Any{a1, a2},
 	}
 }
+
+// ParseBGPPeerConfig - take a string and parses it into an array of peers
+func ParseBGPPeerConfig(config string) (bgpPeers []Peer, err error) {
+	peers := strings.Split(config, ",")
+	if len(peers) == 0 {
+		return nil, fmt.Errorf("No BGP Peer configurations found")
+	}
+
+	for x := range peers {
+		peer := strings.Split(peers[x], ":")
+		if len(peer) != 4 {
+			return nil, fmt.Errorf("BGP Peer configuration format error <host>:<AS>:<password>:<multihop>")
+		}
+		ASNumber, err := strconv.Atoi(peer[1])
+		if err != nil {
+			return nil, fmt.Errorf("BGP Peer AS format error [%s]", peer[1])
+
+		}
+		multiHop, err := strconv.ParseBool(peer[3])
+		if err != nil {
+			return nil, fmt.Errorf("BGP MultiHop format error (true/false) [%s]", peer[1])
+		}
+
+		peerConfig := Peer{
+			Address:  peer[0],
+			AS:       uint32(ASNumber),
+			Password: peer[2],
+			MultiHop: multiHop,
+		}
+
+		bgpPeers = append(bgpPeers, peerConfig)
+	}
+	return
+}

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -66,6 +66,7 @@ type Config struct {
 	// BGP Configuration
 	BGPConfig     bgp.Config
 	BGPPeerConfig bgp.Peer
+	BGPPeers      []string
 
 	// EnablePacket, will use the packet API to update the EIP <-> VIP (if BGP is enabled then BGP will be used)
 	EnablePacket bool `yaml:"enablePacket"`


### PR DESCRIPTION
This adds the `--bgppeers` flag that allows taking multiple peers in a comma seperated fashion:

```
kube-vip manifest pod --interface ens192 --vip 192.1.68.0.40 --bgp --controlplane --bgppeers 192.168.0.1:65000::true,192.168.0.2:6543::true
```

Fixes #132 