### PR TITLE
Bootstrap continuous integration via GitHub Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: For each commit and PR
+on:
+  push:
+  pull_request:
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Init
+      run: apt-get update && apt-get install -y build-essential golint
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.15'
+    - name: checks
+      run: make check
+    - name: test docker build
+      run: make dockerLocal

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,11 @@ simplify:
 	@gofmt -s -l -w $(SRC)
 
 check:
+	@go mod tidy
+	@test -z "$(git status --porcelain)"
 	@test -z $(shell gofmt -l main.go | tee /dev/stderr) || echo "[WARN] Fix formatting issues with 'make fmt'"
 	@for d in $$(go list ./... | grep -v /vendor/); do golint $${d}; done
-	@go tool vet ${SRC}
+	@go vet ${SRC}
 
 run: install
 	@$(TARGET)


### PR DESCRIPTION
- Bootstrap CI for kube-vip on GitHub Action
- Fixed deprecated call to go vet and add go mod tidy
