### PR TITLE
Annotations watcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.3.0
+VERSION := 0.3.1
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -80,10 +80,10 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.AddPeersAsBackends, "addPeersToLB", true, "Add raft peers to the load-balancer")
 
 	// Packet flags
-	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnablePacket, "packet", false, "This will use the Packet API (requires the token ENV) to update the EIP <-> VIP")
-	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PacketAPIKey, "packetKey", "", "The API token for authenticating with the Packet API")
-	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PacketProject, "packetProject", "", "The name of project already created within Packet")
-	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PacketProjectID, "packetProjectID", "", "The ID of project already created within Packet")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableMetal, "metal", false, "This will use the Equinix Metal API (requires the token ENV) to update the EIP <-> VIP")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.MetalAPIKey, "metalKey", "", "The API token for authenticating with the Equinix Metal API")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.MetalProject, "metalProject", "", "The name of project already created within Equinix Metal")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.MetalProjectID, "metalrojectID", "", "The ID of project already created within Equinix Metal")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ProviderConfig, "provider-config", "", "The path to a provider configuration")
 
 	// Load Balancer flags
@@ -209,14 +209,14 @@ var kubeVipManager = &cobra.Command{
 		}
 
 		// If Packet is enabled and there is a provider configuration passed
-		if initConfig.EnablePacket {
+		if initConfig.EnableMetal {
 			if providerConfig != "" {
 				providerAPI, providerProject, err := packet.GetPacketConfig(providerConfig)
 				if err != nil {
 					log.Fatalf("%v", err)
 				}
-				initConfig.PacketAPIKey = providerAPI
-				initConfig.PacketProject = providerProject
+				initConfig.MetalAPIKey = providerAPI
+				initConfig.MetalProject = providerProject
 			}
 		}
 

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -67,6 +67,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.Port, "port", 6443, "listen port for the VIP")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIPCIDR, "cidr", "32", "The CIDR range for the virtual IP address")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableARP, "arp", false, "Enable Arp for Vip changes")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Annotations, "annotations", "", "Set Node annotations prefix for parsing")
 
 	// Clustering type (leaderElection)
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableLeaderElection, "leaderElection", false, "Use the Kubernetes leader election mechanism for clustering")

--- a/docs/hybrid/daemonset/index.md
+++ b/docs/hybrid/daemonset/index.md
@@ -136,7 +136,11 @@ spec:
 
 ## Equinix Metal Overview (using the [Equinix Metal CCM](https://github.com/packethost/packet-ccm))
 
-The below example is for running `type:LoadBalancer` services on worker nodes only and will create a daemonset that will run `kube-vip`. This use-case requires the [Equinix Metal CCM](https://github.com/packethost/packet-ccm) to be installed and that the cluster/kubelet is configured to use an "external" cloud provider. This is important as the CCM will apply the BGP configuration to the [node annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) making it easy for `kube-vip` to find the networking configuration it needs to expose load balancer addresses. The `--annotations packet.com` will cause kube-vip to "watch" the annotations of the worker node that it is running on, once all of the configuarion has been applied by the CCM then the `kube-vip` pod is ready to advertise BGP addresses for the service.
+The below example is for running `type:LoadBalancer` services on worker nodes only and will create a daemonset that will run `kube-vip`. 
+
+**NOTE** This use-case requires the [Equinix Metal CCM](https://github.com/packethost/packet-ccm) to be installed and that the cluster/kubelet is configured to use an "external" cloud provider.
+
+This is important as the CCM will apply the BGP configuration to the [node annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) making it easy for `kube-vip` to find the networking configuration it needs to expose load balancer addresses. The `--annotations packet.com` will cause kube-vip to "watch" the annotations of the worker node that it is running on, once all of the configuarion has been applied by the CCM then the `kube-vip` pod is ready to advertise BGP addresses for the service.
 
 ```
 kube-vip manifest daemonset \

--- a/docs/hybrid/daemonset/index.md
+++ b/docs/hybrid/daemonset/index.md
@@ -36,10 +36,10 @@ This section only covers generating a simple *BGP* configuration, as the main fo
 The easiest method to generate a manifest is using the container itself, below will create an alias for different container runtimes.
 
 #### containerd
-`alias kube-vip="ctr run --rm --net-host docker.io/plndr/kube-vip:0.3.0 vip"`
+`alias kube-vip="ctr run --rm --net-host docker.io/plndr/kube-vip:0.3.1 vip"`
 
 #### Docker
-`alias kube-vip="docker run --network host --rm plndr/kube-vip:0.3.0"`
+`alias kube-vip="docker run --network host --rm plndr/kube-vip:0.3.1"`
 
 ### BGP Example
 
@@ -134,7 +134,37 @@ spec:
 - `hostNetwork: true` - This pod will need to modify interfaces (for VIPs)
 - `env {...}` - We pass the configuration into the kube-vip pod through environment variables.
 
-## K3s overview (on packet)
+## Equinix Metal Overview (using the [Equinix Metal CCM](https://github.com/packethost/packet-ccm))
+
+The below example is for running `type:LoadBalancer` services on worker nodes only and will create a daemonset that will run `kube-vip`. This use-case requires the [Equinix Metal CCM](https://github.com/packethost/packet-ccm) to be installed and that the cluster/kubelet is configured to use an "external" cloud provider. This is important as the CCM will apply the BGP configuration to the [node annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) making it easy for `kube-vip` to find the networking configuration it needs to expose load balancer addresses. The `--annotations packet.com` will cause kube-vip to "watch" the annotations of the worker node that it is running on, once all of the configuarion has been applied by the CCM then the `kube-vip` pod is ready to advertise BGP addresses for the service.
+
+```
+kube-vip manifest daemonset \
+  --interface $INTERFACE \
+  --services \
+  --bgp \
+  --annotations packet.com \
+  --inCluster | k apply -f -
+```
+
+### Troubleshooting
+
+If `kube-vip` has been sat waiting for a long time then you may need to investigate that the annotations have been applied correctly by doing running the `describe` on the node:
+
+```
+kubectl describe node k8s.bgp02
+...
+Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+                    node.alpha.kubernetes.io/ttl: 0
+                    packet.com/node-asn: 65000
+                    packet.com/peer-asn: 65530
+                    packet.com/peer-ip: x.x.x.x
+                    packet.com/src-ip: x.x.x.x
+```
+
+Additionally examining the logs of the Packet CCM may reveal why the node is not yet ready.
+
+## K3s overview (on Equinix Metal)
 
 ### Step 1: TIDY (best if something was running before)
 `rm -rf /var/lib/rancher /etc/rancher ~/.kube/*; ip addr flush dev lo; ip addr add 127.0.0.1/8 dev lo; mkdir -p /var/lib/rancher/k3s/server/manifests/`
@@ -158,7 +188,7 @@ kube-vip manifest daemonset \
   --inCluster \
   --taint \
   --bgp \
-  --packet \
+  --metal \
   --provider-config /etc/cloud-sa/cloud-sa.json | tee /var/lib/rancher/k3s/server/manifests/vip.yaml
 ```
 

--- a/docs/hybrid/index.md
+++ b/docs/hybrid/index.md
@@ -84,16 +84,17 @@ When using `kube-vip` as a daemonset the details are available [here](./daemonse
 |              |`--bgpRouterID`|`<IP Address>`|Typically the address of the local node|
 |              |`--localAS`|default 65000|The AS we peer from|
 |              |`--bgppeers`|`<address:AS:password:mutlihop>`|Comma seperate list of BGP peers|
-|              |`--peerAddress`|`<IP Address>`|(deprecated), Address of a single BGP Peer|
-|              |`--peerAS`|default 65000|(deprecated), AS of a single BGP Peer|
-|              |`--peerPass`|""|(deprecated), Password to work with a single BGP Peer|
-|              |`--multiHop`|Enables eBGP MultiHop|(deprecated), Enable multiHop with a single BGP Peer|
-|**Packet**|||(To be deprecated)|
-|              |`--packet`|Enables Packet API calls||
-|              |`--packetKey`|Packet API token||
-|              |`--packetProject`|Packet Project (Name)||
-|              |`--packetProjectID`|Packet Project (UUID)||
-|              |`--provider-config`|Path to the Packet provider configuration|Requires the Packet CCM|
+|              |`--peerAddress`|`<IP Address>`|Address of a single BGP Peer|
+|              |`--peerAS`|default 65000|AS of a single BGP Peer|
+|              |`--peerPass`|""| Password to work with a single BGP Peer|
+|              |`--multiHop`|Enables eBGP MultiHop| Enable multiHop with a single BGP Peer|
+|              |`--annotaions`|`<provider string>`|Startup will be paused until the node annotaions contain the BGP configuration|
+|**Equinix Metal**|||(May be deprecated)|
+|              |`--metal`|Enables Equinix Metal API calls||
+|              |`--metalKey`|Equinix Metal API token||
+|              |`--metalProject`|Equinix Metal Project (Name)||
+|              |`--metalProjectID`|Equinix Metal Project (UUID)||
+|              |`--provider-config`|Path to the Equinix Metal provider configuration|Requires the Equinix Metal CCM|
 
 ## Changelog
 
@@ -121,20 +122,20 @@ The following new flags are used:
 - `--peerAS` The AS number for a BGP peer
 - `--peerAddress` The address of a BGP peer
 
-### BGP Packet support
+### Equinix Metal BGP support
 
-If the `--bgp` flag is passed alone with the Packet flags `packet, packetKey and packetProject`, then the Packet API will be used in order to determine the BGP configuration for the nodes being used in the cluster. This automates a lot of the process and makes using BGP within Packet much simpler.
+If the `--bgp` flag is passed along with the Equinix Metal flags `metal, metalKey and metalProject`, then Equinix Metal  API will be used in order to determine the BGP configuration for the nodes being used in the cluster. This automates a lot of the process and makes using BGP within Equinix Metal much simpler.
 
-## Packet Support (added in 0.1.7)
+## Equinix Metal Control Plane Support (added in 0.1.8)
 
-Recently in version `0.1.7` of `kube-vip` we added the functionality to use a Packet Elastic IP as the virtual IP fronting the Kubernetes Control plane cluster. In order to first get out virtual IP we will need to use our Packet account and create a EIP (either public (eek) or private). We will only need a single address so a `/32` will suffice, once this is created as part of a Packet project we can now apply this address to the servers that live in the same project. 
+Recently in version `0.1.7` of `kube-vip` we added the functionality to use a Equinix Metal Elastic IP as the virtual IP fronting the Kubernetes Control plane cluster. In order to first get out virtual IP we will need to use our Equinix Metal account and create a EIP (either public or private). We will only need a single address so a `/32` will suffice, once this is created as part of a Equinix Metal project we can now apply this address to the servers that live in the same project. 
 
 In this example we've logged into the UI can created a new EIP of `147.75.1.2`, and we've deployed three small server instances with Ubuntu.
 
 The following new flags are used:
 
-- `--packet` which enables the use of the Packet API
-- `--packetKey` which is our API key
-- `--packetProject`which is the name of our Packet project where our servers and EIP are located.
+- `--metal` which enables the use of the Equinix Metal API
+- `--metalKey` which is our API key
+- `--metalProject`which is the name of our Equinix Metal project where our servers and EIP are located.
 
-*Also* the `--arp` flag should NOT be used as it wont work within the Packet network.
+*Also* the `--arp` flag should NOT be used as it wont work within the Equinix Metal network.

--- a/docs/hybrid/services/index.md
+++ b/docs/hybrid/services/index.md
@@ -166,7 +166,7 @@ $ curl externalIP:32380
 ...
 ```
 
-### Expose with packet (using the `plndr-cloud-provider`)
+### Expose with Equinix Metal (using the `plndr-cloud-provider`)
 
 Either through the CLI or through the UI, create a public IPv4 EIP address.. and this is the address you can expose through BGP!
 

--- a/docs/manifests/rbac.yaml
+++ b/docs/manifests/rbac.yaml
@@ -12,7 +12,7 @@ metadata:
   name: system:kube-vip-role
 rules:
   - apiGroups: [""]
-    resources: ["services", "services/status"]
+    resources: ["services", "services/status", "nodes"]
     verbs: ["list","get","watch", "update"]
 ---
 kind: ClusterRoleBinding

--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -15,7 +15,7 @@ func (b *Server) AddHost(addr string) (err error) {
 	}
 	p := b.getPath(ip)
 	if p == nil {
-		return
+		return err
 	}
 
 	_, err = b.s.AddPath(context.Background(), &api.AddPathRequest{

--- a/pkg/cluster/clusterLeader.go
+++ b/pkg/cluster/clusterLeader.go
@@ -152,7 +152,7 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 
 	// If Packet is enabled then we can begin our preperation work
 	var packetClient *packngo.Client
-	if c.EnablePacket {
+	if c.EnableMetal {
 		packetClient, err = packngo.NewClient()
 		if err != nil {
 			log.Error(err)
@@ -229,7 +229,7 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 					log.Warnf("%v", err)
 				}
 
-				if c.EnablePacket {
+				if c.EnableMetal {
 					// We're not using Packet with BGP
 					if !c.EnableBGP {
 						// Attempt to attach the EIP in the standard manner

--- a/pkg/cluster/singleNode.go
+++ b/pkg/cluster/singleNode.go
@@ -108,7 +108,7 @@ func (cluster *Cluster) StartSingleNode(c *kubevip.Config, disableVIP bool) erro
 // StartLoadBalancerService will start a VIP instance and leave it for kube-proxy to handle
 func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Server) error {
 	// Start a kube-vip loadbalancer service
-	log.Infoln("Starting kube-vip as a LoadBalancer Service")
+	log.Infof("Starting advertising address [%s] with kube-vip", c.VIP)
 
 	cluster.stop = make(chan bool, 1)
 	cluster.completed = make(chan bool, 1)
@@ -135,7 +135,6 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 		// Lets advertise the VIP over BGP, the host needs to be passed using CIDR notation
 		cidrVip := fmt.Sprintf("%s/%s", cluster.Network.IP(), c.VIPCIDR)
 		log.Debugf("Attempting to advertise the address [%s] over BGP", cidrVip)
-
 		err = bgp.AddHost(cidrVip)
 		if err != nil {
 			log.Error(err)

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -1,0 +1,134 @@
+package kubevip
+
+// Environment variables
+const (
+
+	//vipArp - defines if the arp broadcast should be enabled
+	vipArp = "vip_arp"
+
+	//vipLeaderElection - defines if the kubernetes algorithim should be used
+	vipLeaderElection = "vip_leaderelection"
+
+	//vipLeaderElection - defines if the kubernetes algorithim should be used
+	vipLeaseDuration = "vip_leaseduration"
+
+	//vipLeaderElection - defines if the kubernetes algorithim should be used
+	vipRenewDeadline = "vip_renewdeadline"
+
+	//vipLeaderElection - defines if the kubernetes algorithim should be used
+	vipRetryPeriod = "vip_retryperiod"
+
+	//vipLogLevel - defines the level of logging to produce (5 being the most verbose)
+	vipLogLevel = "vip_loglevel"
+
+	//vipInterface - defines the interface that the vip should bind too
+	vipInterface = "vip_interface"
+
+	//vipCidr - defines the cidr that the vip will use
+	vipCidr = "vip_cidr"
+
+	/////////////////////////////////////
+	// TO DO:
+	// Determine how to tidy this mess up
+	/////////////////////////////////////
+
+	//vipAddress - defines the address that the vip will expose
+	// DEPRECATED: will be removed in a next release
+	vipAddress = "vip_address"
+
+	// address - defines the address that would be used as a vip
+	// it may be an IP or a DNS name, in case of a DNS name
+	// kube-vip will try to resolve it and use the IP as a VIP
+	address = "address"
+
+	//port - defines the port for the VIP
+	port = "port"
+
+	// annotations
+	annotations = "annotation"
+
+	//vipDdns - defines if use dynamic dns to allocate IP for "address"
+	vipDdns = "vip_ddns"
+
+	//vipSingleNode - defines the vip start as a single node cluster
+	vipSingleNode = "vip_singlenode"
+
+	//vipStartLeader - will start this instance as the leader of the cluster
+	vipStartLeader = "vip_startleader"
+
+	//vipPeers defines the configuration of raft peer(s)
+	vipPeers = "vip_peers"
+
+	//vipLocalPeer defines the configuration of the local raft peer
+	vipLocalPeer = "vip_localpeer"
+
+	//vipRemotePeers defines the configuration of the local raft peer
+	vipRemotePeers = "vip_remotepeers"
+
+	//vipAddPeersToLB defines that RAFT peers should be added to the load-balancer
+	vipAddPeersToLB = "vip_addpeerstolb"
+
+	//vipPacket defines that the packet API will be used for EIP
+	vipPacket = "vip_packet"
+
+	//vipPacketProject defines which project within Packet to use
+	vipPacketProject = "vip_packetproject"
+
+	//vipPacketProjectID defines which projectID within Packet to use
+	vipPacketProjectID = "vip_packetprojectid"
+
+	//providerConfig defines a path to a configuration that should be parsed
+	providerConfig = "provider_config"
+
+	//bgpEnable defines if BGP should be enabled
+	bgpEnable = "bgp_enable"
+	//bgpRouterID defines the routerID for the BGP server
+	bgpRouterID = "bgp_routerid"
+	//bgpRouterInterface defines the interface that we can find the address for
+	bgpRouterInterface = "bgp_routerinterface"
+	//bgpRouterAS defines the AS for the BGP server
+	bgpRouterAS = "bgp_as"
+	//bgpPeerAddress defines the address for a BGP peer
+	bgpPeerAddress = "bgp_peeraddress"
+	//bgpPeers defines the address for a BGP peer
+	bgpPeers = "bgp_peers"
+	//bgpPeerAS defines the AS for a BGP peer
+	bgpPeerAS = "bgp_peeras"
+	//bgpPeerAS defines the AS for a BGP peer
+	bgpPeerPassword = "bgp_peerpass"
+	//bgpMultiHop enables mulithop routing
+	bgpMultiHop = "bgp_multihop"
+
+	//cpNamespace defines the namespace the control plane pods will run in
+	cpNamespace = "cp_namespace"
+
+	//cpEnable starts kube-vip in the hybrid mode
+	cpEnable = "cp_enable"
+
+	//cpEnable starts kube-vip in the hybrid mode
+	svcEnable = "svc_enable"
+
+	//lbEnable defines if the load-balancer should be enabled
+	lbEnable = "lb_enable"
+
+	//lbBindToVip defines if the load-balancer should bind ONLY to the virtual IP
+	lbBindToVip = "lb_bindtovip"
+
+	//lbName defines the name of load-balancer
+	lbName = "lb_name"
+
+	//lbType defines the type of load-balancer
+	lbType = "lb_type"
+
+	//lbPort defines the port of load-balancer
+	lbPort = "lb_port"
+
+	//lbBackendPort defines a port that ALL backends are using
+	lbBackendPort = "lb_backendport"
+
+	//lbBackends defines the backends of load-balancer
+	lbBackends = "lb_backends"
+
+	//vipConfigMap defines the configmap that kube-vip will watch for service definitions
+	vipConfigMap = "vip_configmap"
+)

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -321,21 +321,21 @@ func ParseEnvironment(c *Config) error {
 		if err != nil {
 			return err
 		}
-		c.EnablePacket = b
+		c.EnableMetal = b
 	}
 
 	// Find the Packet project name
 	env = os.Getenv(vipPacketProject)
 	if env != "" {
 		// TODO - parse address net.Host()
-		c.PacketProject = env
+		c.MetalProject = env
 	}
 
 	// Find the Packet project ID
 	env = os.Getenv(vipPacketProjectID)
 	if env != "" {
 		// TODO - parse address net.Host()
-		c.PacketProjectID = env
+		c.MetalProjectID = env
 	}
 
 	// Enable the load-balancer
@@ -565,23 +565,23 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 	}
 
 	// If Packet is enabled then add it to the manifest
-	if c.EnablePacket {
+	if c.EnableMetal {
 		packet := []corev1.EnvVar{
 			{
 				Name:  vipPacket,
-				Value: strconv.FormatBool(c.EnablePacket),
+				Value: strconv.FormatBool(c.EnableMetal),
 			},
 			{
 				Name:  vipPacketProject,
-				Value: c.PacketProject,
+				Value: c.MetalProject,
 			},
 			{
 				Name:  vipPacketProjectID,
-				Value: c.PacketProjectID,
+				Value: c.MetalProjectID,
 			},
 			{
 				Name:  "PACKET_AUTH_TOKEN",
-				Value: c.PacketAPIKey,
+				Value: c.MetalAPIKey,
 			},
 		}
 		newEnvironment = append(newEnvironment, packet...)
@@ -598,7 +598,7 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		newEnvironment = append(newEnvironment, bgp...)
 	}
 	// If BGP, but we're not using packet
-	if c.EnableBGP && !c.EnablePacket {
+	if c.EnableBGP && !c.EnableMetal {
 		bgpConfig := []corev1.EnvVar{
 			{
 				Name:  bgpRouterID,

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -15,136 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Environment variables
-const (
-
-	//vipArp - defines if the arp broadcast should be enabled
-	vipArp = "vip_arp"
-
-	//vipLeaderElection - defines if the kubernetes algorithim should be used
-	vipLeaderElection = "vip_leaderelection"
-
-	//vipLeaderElection - defines if the kubernetes algorithim should be used
-	vipLeaseDuration = "vip_leaseduration"
-
-	//vipLeaderElection - defines if the kubernetes algorithim should be used
-	vipRenewDeadline = "vip_renewdeadline"
-
-	//vipLeaderElection - defines if the kubernetes algorithim should be used
-	vipRetryPeriod = "vip_retryperiod"
-
-	//vipLogLevel - defines the level of logging to produce (5 being the most verbose)
-	vipLogLevel = "vip_loglevel"
-
-	//vipInterface - defines the interface that the vip should bind too
-	vipInterface = "vip_interface"
-
-	//vipCidr - defines the cidr that the vip will use
-	vipCidr = "vip_cidr"
-
-	/////////////////////////////////////
-	// TO DO:
-	// Determine how to tidy this mess up
-	/////////////////////////////////////
-
-	//vipAddress - defines the address that the vip will expose
-	// DEPRECATED: will be removed in a next release
-	vipAddress = "vip_address"
-
-	// address - defines the address that would be used as a vip
-	// it may be an IP or a DNS name, in case of a DNS name
-	// kube-vip will try to resolve it and use the IP as a VIP
-	address = "address"
-
-	//port - defines the port for the VIP
-	port = "port"
-
-	//vipDdns - defines if use dynamic dns to allocate IP for "address"
-	vipDdns = "vip_ddns"
-
-	//vipSingleNode - defines the vip start as a single node cluster
-	vipSingleNode = "vip_singlenode"
-
-	//vipStartLeader - will start this instance as the leader of the cluster
-	vipStartLeader = "vip_startleader"
-
-	//vipPeers defines the configuration of raft peer(s)
-	vipPeers = "vip_peers"
-
-	//vipLocalPeer defines the configuration of the local raft peer
-	vipLocalPeer = "vip_localpeer"
-
-	//vipRemotePeers defines the configuration of the local raft peer
-	vipRemotePeers = "vip_remotepeers"
-
-	//vipAddPeersToLB defines that RAFT peers should be added to the load-balancer
-	vipAddPeersToLB = "vip_addpeerstolb"
-
-	//vipPacket defines that the packet API will be used for EIP
-	vipPacket = "vip_packet"
-
-	//vipPacketProject defines which project within Packet to use
-	vipPacketProject = "vip_packetproject"
-
-	//vipPacketProjectID defines which projectID within Packet to use
-	vipPacketProjectID = "vip_packetprojectid"
-
-	//providerConfig defines a path to a configuration that should be parsed
-	providerConfig = "provider_config"
-
-	//bgpEnable defines if BGP should be enabled
-	bgpEnable = "bgp_enable"
-	//bgpRouterID defines the routerID for the BGP server
-	bgpRouterID = "bgp_routerid"
-	//bgpRouterInterface defines the interface that we can find the address for
-	bgpRouterInterface = "bgp_routerinterface"
-	//bgpRouterAS defines the AS for the BGP server
-	bgpRouterAS = "bgp_as"
-	//bgpPeerAddress defines the address for a BGP peer
-	bgpPeerAddress = "bgp_peeraddress"
-	//bgpPeers defines the address for a BGP peer
-	bgpPeers = "bgp_peers"
-	//bgpPeerAS defines the AS for a BGP peer
-	bgpPeerAS = "bgp_peeras"
-	//bgpPeerAS defines the AS for a BGP peer
-	bgpPeerPassword = "bgp_peerpass"
-	//bgpMultiHop enables mulithop routing
-	bgpMultiHop = "bgp_multihop"
-
-	//cpNamespace defines the namespace the control plane pods will run in
-	cpNamespace = "cp_namespace"
-
-	//cpEnable starts kube-vip in the hybrid mode
-	cpEnable = "cp_enable"
-
-	//cpEnable starts kube-vip in the hybrid mode
-	svcEnable = "svc_enable"
-
-	//lbEnable defines if the load-balancer should be enabled
-	lbEnable = "lb_enable"
-
-	//lbBindToVip defines if the load-balancer should bind ONLY to the virtual IP
-	lbBindToVip = "lb_bindtovip"
-
-	//lbName defines the name of load-balancer
-	lbName = "lb_name"
-
-	//lbType defines the type of load-balancer
-	lbType = "lb_type"
-
-	//lbPort defines the port of load-balancer
-	lbPort = "lb_port"
-
-	//lbBackendPort defines a port that ALL backends are using
-	lbBackendPort = "lb_backendport"
-
-	//lbBackends defines the backends of load-balancer
-	lbBackends = "lb_backends"
-
-	//vipConfigMap defines the configmap that kube-vip will watch for service definitions
-	vipConfigMap = "vip_configmap"
-)
-
 // ParseEnvironment - will popultate the configuration from environment variables
 func ParseEnvironment(c *Config) error {
 
@@ -290,6 +160,12 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.SingleNode = b
+	}
+
+	// Find annotation configuration
+	env = os.Getenv(annotations)
+	if env != "" {
+		c.Annotations = env
 	}
 
 	// Find Start As Leader
@@ -663,6 +539,18 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			},
 		}
 		newEnvironment = append(newEnvironment, raft...)
+	}
+
+	// If we're specifying an annotation configuration
+	if c.Annotations != "" {
+		annotations := []corev1.EnvVar{
+			{
+				Name:  annotations,
+				Value: c.Annotations,
+			},
+		}
+		newEnvironment = append(newEnvironment, annotations...)
+
 	}
 
 	// If we're specifying a configuration

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -71,17 +71,17 @@ type Config struct {
 	BGPPeerConfig bgp.Peer
 	BGPPeers      []string
 
-	// EnablePacket, will use the packet API to update the EIP <-> VIP (if BGP is enabled then BGP will be used)
-	EnablePacket bool `yaml:"enablePacket"`
+	// EnablePacket, will use the metal API to update the EIP <-> VIP (if BGP is enabled then BGP will be used)
+	EnableMetal bool `yaml:"enableMetal"`
 
-	// PacketAPIKey, is the API token used to authenticate to the API
-	PacketAPIKey string
+	// MetalAPIKey, is the API token used to authenticate to the API
+	MetalAPIKey string
 
-	// PacketProject, is the name of a particular defined project
-	PacketProject string
+	// MetalProject, is the name of a particular defined project
+	MetalProject string
 
-	// PacketProjectID, is the name of a particular defined project
-	PacketProjectID string
+	// MetalProjectID, is the name of a particular defined project
+	MetalProjectID string
 
 	// ProviderConfig, is the path to a provider configuration file
 	ProviderConfig string

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -21,6 +21,9 @@ type Config struct {
 	// EnableControlPane, will enable the control plane functionality (used for hybrid behaviour)
 	EnableServices bool `yaml:"enableServices"`
 
+	// Annotations will define if we're going to wait and lookup configuration from Kubernetes node annotations
+	Annotations string
+
 	// LeaderElection defines the settings around Kubernetes LeaderElection
 	LeaderElection
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -145,14 +145,15 @@ func (sm *Manager) Start() error {
 	// Add Notification for SIGKILL (sent from Kubernetes)
 	signal.Notify(sm.signalChan, syscall.SIGKILL)
 
-	// If Annotations have been set then we will look them up
-	err := sm.parseAnnotations()
-	if err != nil {
-		return err
-	}
-
 	// If BGP is enabled then we start a server instance that will broadcast VIPs
 	if sm.config.EnableBGP {
+
+		// If Annotations have been set then we will look them up
+		err := sm.parseAnnotations()
+		if err != nil {
+			return err
+		}
+
 		log.Infoln("Starting Kube-vip Manager with the BGP engine")
 		log.Infof("Namespace [%s], Hybrid mode [%t]", sm.config.Namespace, sm.config.EnableControlPane && sm.config.EnableServices)
 		return sm.startBGP()

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -189,7 +189,7 @@ func fileExists(filename string) bool {
 
 func (sm *Manager) parseAnnotations() error {
 	if sm.config.Annotations == "" {
-		log.Fatalln("No Node annotations to parse")
+		log.Debugf("No Node annotations to parse")
 		return nil
 	}
 

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -57,13 +57,6 @@ func (sm *Manager) startBGP() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go func() {
-		<-sm.signalChan
-		log.Info("Received termination, signaling shutdown")
-		// Cancel the context, which will in turn cancel the leadership
-		cancel()
-	}()
-
 	// Defer a function to check if the bgpServer has been created and if so attempt to close it
 	defer func() {
 		if sm.bgpServer != nil {
@@ -97,7 +90,7 @@ func (sm *Manager) startBGP() error {
 			}
 		}()
 
-		// Check if we're also starting the services, if now we can sit and wait on the closing channel and return here
+		// Check if we're also starting the services, if not we can sit and wait on the closing channel and return here
 		if !sm.config.EnableServices {
 			<-sm.signalChan
 			log.Infof("Shutting down Kube-Vip")

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -47,7 +47,7 @@ func (sm *Manager) startBGP() error {
 		}
 	}
 
-	log.Info("Starting the BGP server to adverise VIP routes to VGP peers")
+	log.Info("Starting the BGP server to adverise VIP routes to BGP peers")
 	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig)
 	if err != nil {
 		return err

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -20,7 +20,7 @@ func (sm *Manager) startBGP() error {
 
 	// If Packet is enabled then we can begin our preperation work
 	var packetClient *packngo.Client
-	if sm.config.EnablePacket {
+	if sm.config.EnableMetal {
 		if sm.config.ProviderConfig != "" {
 			key, project, err := packet.GetPacketConfig(sm.config.ProviderConfig)
 			if err != nil {
@@ -29,7 +29,7 @@ func (sm *Manager) startBGP() error {
 				// Set the environment variable with the key for the project
 				os.Setenv("PACKET_AUTH_TOKEN", key)
 				// Update the configuration with the project key
-				sm.config.PacketProjectID = project
+				sm.config.MetalProjectID = project
 			}
 		}
 		packetClient, err = packngo.NewClient()

--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -3,6 +3,8 @@ package manager
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 
@@ -10,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	watchtools "k8s.io/client-go/tools/watch"
 
 	"k8s.io/apimachinery/pkg/watch"
@@ -88,4 +91,121 @@ func (sm *Manager) servicesWatcher(ctx context.Context) error {
 	}
 	log.Warnln("Stopping watching services for type: LoadBalancer in all namespaces")
 	return nil
+}
+
+// This file handles the watching of node annotations for configuration, it will exit once the annotations are
+// present
+func (sm *Manager) annotationsWatcher() error {
+	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
+	log.Infoln("Kube-Vip is waiting for annotations to be present on this node")
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	// TEST - REMOVE
+	hostname = "k8s.bgp01"
+
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/hostname": hostname}}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+
+	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return sm.clientSet.CoreV1().Nodes().Watch(context.Background(), listOptions)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error creating annotations watcher: %s", err.Error())
+	}
+
+	go func() {
+		<-sm.signalChan
+		log.Info("Received termination, signaling shutdown")
+		// Cancel the context
+		rw.Stop()
+	}()
+
+	ch := rw.ResultChan()
+	//defer rw.Stop()
+
+	for event := range ch {
+
+		// We need to inspect the event and get ResourceVersion out of it
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			// log.Debugf("Endpoints for service [%s] have been Created or modified", s.service.ServiceName)
+			node, ok := event.Object.(*v1.Node)
+			if !ok {
+				return fmt.Errorf("Unable to parse Kubernetes services from API watcher")
+			}
+
+			nodeAsn := node.Annotations[fmt.Sprintf("%s/node-asn", sm.config.Annotations)]
+			if nodeAsn != "" {
+				u64, err := strconv.ParseUint(nodeAsn, 10, 32)
+				if err != nil {
+					return err
+				}
+				sm.config.BGPConfig.AS = uint32(u64)
+			} else {
+				continue
+			}
+			srcIP := node.Annotations[fmt.Sprintf("%s/src-ip", sm.config.Annotations)]
+			if srcIP != "" {
+				sm.config.BGPConfig.SourceIP = srcIP
+			} else {
+				continue
+			}
+			peerASN := node.Annotations[fmt.Sprintf("%s/peer-asn", sm.config.Annotations)]
+			if peerASN != "" {
+				u64, err := strconv.ParseUint(peerASN, 10, 32)
+				if err != nil {
+					return err
+				}
+				sm.config.BGPPeerConfig.AS = uint32(u64)
+			} else {
+				continue
+			}
+			peerIP := node.Annotations[fmt.Sprintf("%s/peer-ip", sm.config.Annotations)]
+			if peerIP != "" {
+				sm.config.BGPPeerConfig.Address = peerIP
+			} else {
+				continue
+			}
+			// Add the peer configuration to the overall BGP configuration
+			log.Infoln("Annotations have been succesfully parsed")
+			sm.config.BGPConfig.Peers = append(sm.config.BGPConfig.Peers, sm.config.BGPPeerConfig)
+			rw.Stop()
+			break
+		case watch.Deleted:
+			node, ok := event.Object.(*v1.Node)
+			if !ok {
+				return fmt.Errorf("Unable to parse Kubernetes services from API watcher")
+			}
+
+			log.Infof("Node [%s] has been deleted", node.Name)
+
+		case watch.Bookmark:
+			// Un-used
+		case watch.Error:
+			log.Error("Error attempting to watch Kubernetes services")
+
+			// This round trip allows us to handle unstructured status
+			errObject := apierrors.FromObject(event.Object)
+			statusErr, ok := errObject.(*apierrors.StatusError)
+			if !ok {
+				log.Errorf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+
+			}
+
+			status := statusErr.ErrStatus
+			log.Errorf("%v", status)
+		default:
+		}
+	}
+
+	log.Infoln("Exiting Annotations watcher")
+	return nil
+
 }

--- a/pkg/packet/bgp.go
+++ b/pkg/packet/bgp.go
@@ -9,17 +9,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// BGPLookup will use the Packet API functions to populate the BGP information
+// BGPLookup will use the Equinix Metal API functions to populate the BGP information
 func BGPLookup(c *packngo.Client, k *kubevip.Config) error {
 	var thisDevice *packngo.Device
-	if k.PacketProjectID == "" {
-		proj := findProject(k.PacketProject, c)
+	if k.MetalProjectID == "" {
+		proj := findProject(k.MetalProject, c)
 		if proj == nil {
-			return fmt.Errorf("Unable to find Project [%s]", k.PacketProject)
+			return fmt.Errorf("Unable to find Project [%s]", k.MetalProject)
 		}
 		thisDevice = findSelf(c, proj.ID)
 	} else {
-		thisDevice = findSelf(c, k.PacketProjectID)
+		thisDevice = findSelf(c, k.MetalProjectID)
 	}
 	if thisDevice == nil {
 		return fmt.Errorf("Unable to find local/this device in packet API")

--- a/pkg/packet/eip.go
+++ b/pkg/packet/eip.go
@@ -13,9 +13,9 @@ import (
 func AttachEIP(c *packngo.Client, k *kubevip.Config, hostname string) error {
 
 	// Find our project
-	proj := findProject(k.PacketProject, c)
+	proj := findProject(k.MetalProject, c)
 	if proj == nil {
-		return fmt.Errorf("Unable to find Project [%s]", k.PacketProject)
+		return fmt.Errorf("Unable to find Project [%s]", k.MetalProject)
 	}
 
 	ips, _, _ := c.ProjectIPs.List(proj.ID, &packngo.ListOptions{})

--- a/pkg/service/manager_bgp.go
+++ b/pkg/service/manager_bgp.go
@@ -21,7 +21,7 @@ func (sm *Manager) startBGP() error {
 
 	// If Packet is enabled then we can begin our preperation work
 	var packetClient *packngo.Client
-	if sm.config.EnablePacket {
+	if sm.config.EnableMetal {
 		packetClient, err = packngo.NewClient()
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
This now offers the `--annotations <provider>` flag, this is used to watch for BGP annotations being applied and will watch for: 

`<provider>/src-ip`
`<provider>/node-asn`
`<provider>/peer-ip`
`<provider>/peer-asn`

Once all these have been populated the watch ends and starts the BGP server