### PR TITLE
Fixes packet -> metal

### DIFF
--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -770,7 +770,7 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			Name: "cloud-sa-volume",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: "packet-cloud-config",
+					SecretName: "metal-cloud-config",
 				},
 			},
 		}


### PR DESCRIPTION
This updates the hardcoded secret name that is shared between kube-vip and the Equinix Metal CCM.