### PR TITLE
leaderelection exit when the election is lost

### DIFF
--- a/pkg/cluster/clusterLeader.go
+++ b/pkg/cluster/clusterLeader.go
@@ -323,6 +323,8 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 				if err != nil {
 					log.Warnf("%v", err)
 				}
+
+				log.Fatal("lost leadership, restarting kube-vip")
 			},
 			OnNewLeader: func(identity string) {
 				// we're notified when new leader elected
@@ -334,12 +336,6 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 			},
 		},
 	})
-
-	//<-signalChan
-	log.Infof("Shutting down Kube-Vip Leader Election cluster")
-
-	// Force a removal of the VIP (ignore the error if we don't have it)
-	cluster.Network.DeleteIP()
 
 	return nil
 }

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -133,6 +133,8 @@ func (sm *Manager) startARP() error {
 				for x := range sm.serviceInstances {
 					sm.serviceInstances[x].cluster.Stop()
 				}
+
+				log.Fatal("lost leadership, restarting kube-vip")
 			},
 			OnNewLeader: func(identity string) {
 				// we're notified when new leader elected
@@ -144,9 +146,6 @@ func (sm *Manager) startARP() error {
 			},
 		},
 	})
-
-	//<-signalChan
-	log.Infof("Shutting down Kube-Vip")
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

This PR adds code to exit when the cleanup is done. This is especially useful when running on a single node cluster, where there's no other kube-vip pod to takeover the lease