### PR TITLE
Catch return value for StartLeaderCluster

### DIFF
--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -48,7 +48,7 @@ func (sm *Manager) startARP() error {
 		}
 
 		go func() {
-			cpCluster.StartLeaderCluster(sm.config, clusterManager, nil)
+			err := cpCluster.StartLeaderCluster(sm.config, clusterManager, nil)
 			if err != nil {
 				log.Errorf("Control Pane Error [%v]", err)
 				// Trigger the shutdown of this manager instance


### PR DESCRIPTION
Error handling for the function StartLeaderCluster is not properly done.

Fixed #169 

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>