### PR TITLE
fix: unassign IPs correctly for Equinix Metal

### DIFF
--- a/pkg/packet/eip.go
+++ b/pkg/packet/eip.go
@@ -2,7 +2,7 @@ package packet
 
 import (
 	"fmt"
-	"strings"
+	"path"
 
 	"github.com/packethost/packngo"
 	"github.com/plunder-app/kube-vip/pkg/kubevip"
@@ -26,7 +26,7 @@ func AttachEIP(c *packngo.Client, k *kubevip.Config, hostname string) error {
 			log.Infof("Found EIP ->%s ID -> %s\n", ip.Address, ip.ID)
 			// If attachements already exist then remove them
 			if len(ip.Assignments) != 0 {
-				hrefID := strings.Replace(ip.Assignments[0].Href, "/ips/", "", -1)
+				hrefID := path.Base(ip.Assignments[0].Href)
 				c.DeviceIPs.Unassign(hrefID)
 			}
 		}


### PR DESCRIPTION
IP assignment href returned from the API looks like:

```
/metal/v1/ips/97972920-f00b-453f-be1e-31eb53c19e38
```

It should be cleaned up to contain ID only, removing `/ips/` leads to
broken requests like:

```
2021/04/15 12:03:41 [DEBUG] DELETE https://api.equinix.com/metal/v1/ips//metal/v197972920-f00b-453f-be1e-31eb53c19e38
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>