### PR TITLE
Fixes interface on networking restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := 0.3.3
+VERSION := 0.3.4
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)


### PR DESCRIPTION
This change adds:

- Replace networking configuration when it's removed `systemctl restart networkd` etc..
- Regular ARP broadcasts for service load balancer messages.